### PR TITLE
Fix parseCookie function to accept string[] for the case where there's multiple cookies

### DIFF
--- a/abods-api/src/resolvers/helpers.ts
+++ b/abods-api/src/resolvers/helpers.ts
@@ -76,13 +76,12 @@ export const requireUserSession = async (context: RequestContext) => {
 };
 
 
-function getHeader(headers: IncomingHttpHeaders, name: string) {
+function getHeader(headers: IncomingHttpHeaders, name: string): string | string[] | undefined {
   return headers[name.toLowerCase()] || headers[name.toUpperCase()] || headers[name];
 }
 
-const parseCookie = (str: string) =>
-  str
-    .split(';')
+const parseCookie = (str: string | string[]) =>
+  (typeof str === 'string' ? str.split(';') : str)
     .map((v) => v.split('='))
     .reduce((acc: { [key: string]: string }, v) => {
       acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());


### PR DESCRIPTION
This fixes this build error:

```
Error: src/resolvers/helpers.ts(23,31): error TS2345: Argument of type 'string | string[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.
```