### PR TITLE
Add kms:Decrypt to the API Lambda's permissions

### DIFF
--- a/abods-api/template.yaml
+++ b/abods-api/template.yaml
@@ -191,6 +191,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - kms:Decrypt
+                  - kms:DescribeKey
                 Resource:
                   Fn::Sub: '{{resolve:ssm:/${ProjectName}/shared/kms/secretsmanager/arn}}'
   GraphQlFunctionLoggingPolicy:


### PR DESCRIPTION
The lambda needs permissionto use the KMS key to decrypt the secret holding the API Key hash and HMAC