### PR TITLE
fix to set seconds and milliseconds to zero when time filter is used

### DIFF
--- a/abods-api/src/lib/otp.ts
+++ b/abods-api/src/lib/otp.ts
@@ -112,15 +112,13 @@ export const compareThresholds = async (
 
   if (startTime) {
     const [hours, minutes, _] = startTime.split(":").map(Number);
-    start.setHours(hours);
-    start.setMinutes(minutes, 0, 0);
+    start.setHours(hours, minutes, 0, 0);
     departure_hour.gte = start;
   }
 
   if (endTime) {
     const [hours, minutes, _] = endTime.split(":").map(Number);
-    end.setHours(hours);
-    end.setMinutes(minutes, 0, 0);
+    end.setHours(hours, minutes, 0, 0);
     departure_hour.lte = end;
   }
 


### PR DESCRIPTION
fix to set seconds and milliseconds to zero when time filter is used