### PR TITLE
moved db context within graphql server context so that any error from creating context is handled

### DIFF
--- a/abods-api/package.json
+++ b/abods-api/package.json
@@ -39,7 +39,6 @@
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "datadog-lambda-js": "^9.117.0",
     "dayjs": "^1.11.11",
     "dayjs-plugin-utc": "^0.1.2",
     "express-session": "^1.18.0",


### PR DESCRIPTION
moved db context within graphql server context so that any error from creating context is handled