### PR TITLE
Fix helpdesk panel styling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "angular-google-tag-manager": "~1.11.0",
         "angular-svg-icon": "^13.0.0",
         "apollo-angular": "^8.0.0",
-        "govuk-frontend": "^5.10.0",
+        "govuk-frontend": "^5.10.1",
         "graphql": "^16.10.0",
         "lodash-es": "^4.17.20",
         "luxon": "^2.5.2",
@@ -13039,9 +13039,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.0.tgz",
-      "integrity": "sha512-9tjpB8PDwsDqutkQPJXfDalLvNOeKxzFhV7me21s/oyn7HcTg/ei/GC3Y4JvNsXauzjOkxv4eeCHntKeySkdMg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.1.tgz",
+      "integrity": "sha512-VmzKE+pkuOqEXhit0cGqic4i2mOQwflfXDiEcsa6Lrqs//rxV5AYf+C71jbREPwQLH4wYSJAlz/GlGoO5nik7Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "angular-google-tag-manager": "~1.11.0",
     "angular-svg-icon": "^13.0.0",
     "apollo-angular": "^8.0.0",
-    "govuk-frontend": "^5.10.0",
+    "govuk-frontend": "^5.10.1",
     "graphql": "^16.10.0",
     "lodash-es": "^4.17.20",
     "luxon": "^2.5.2",

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -37,9 +37,11 @@
 
   <body class="govuk-template__body">
     <script>
-      document.body.className = document.body.className
-        ? document.body.className + " js-enabled"
-        : "js-enabled";
+      document.body.className +=
+        " js-enabled" +
+        ("noModule" in HTMLScriptElement.prototype
+          ? " govuk-frontend-supported"
+          : "");
     </script>
     <app-root>
       <div class="spinner spinner--vcentre">


### PR DESCRIPTION
The styling for the help desk panel is broken. It seems that this breaking change occurred when we [previously updated the govuk-frontend package from v4.5.0 to v5.9.0](https://github.com/department-for-transport-BODS/abods/pull/362/files#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R43).

The [v5.0.0 release](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0) contained some breaking changes that we missed - specifically, we needed to replace the script for updating the class names on the body element. The new css class `govuk-frontend-supported` is used instead of `js-enabled` to apply styling to the help desk panel

Example of what it looked like before this PR:
<img width="1728" alt="Screenshot 2025-05-16 at 12 22 16" src="https://github.com/user-attachments/assets/e07152b9-8820-4945-8d11-61959feae2ca" />

Example of what it looks like after this PR:
<img width="1728" alt="Screenshot 2025-05-16 at 12 21 17" src="https://github.com/user-attachments/assets/34f4b8d6-d2c7-4dea-85fb-0d2cdb4de5b7" />
