### PR TITLE
BODS-9236: Add scheduled distance and route to vehicle journeys page

### DIFF
--- a/abods-api/prisma/schema.prisma
+++ b/abods-api/prisma/schema.prisma
@@ -471,6 +471,12 @@ model feed_monitor_daily_summary {
   availability     Decimal? @db.Decimal
 }
 
+model transmodel_servicepatterndistance {
+  service_pattern_id Int    @id
+  distance           Int?
+  geom               String?
+}
+
 model servicepattern_route {
   distinct_route_id            Int             @unique // TODO: fix - not unique in db
   noc_and_line_and_servicecode String

--- a/abods-api/schema.graphql
+++ b/abods-api/schema.graphql
@@ -1,6 +1,7 @@
 scalar DateTime
 scalar Time
 scalar Date
+scalar JSON
 
 type Query {
   user: LoginInfo
@@ -27,6 +28,9 @@ type Query {
   ): [EventStatsType!]!
   journey(groupId: String!, lineId: String!): JourneyResult!
   findJourneys(lineId: String!, dateOfJourney: String!): [Journey!]!
+  getServicePatternDistanceGeom(
+    vehicleJourneyId: ID!
+  ): ServicePatternDistanceResult!
   lines(
     operatorIds: [String!]!
     inputDate: String!
@@ -226,6 +230,7 @@ type Journey {
   serviceNumber: String!
   operatorName: String!
   operatorNoc: String!
+  vehicleJourneyId: Int
 }
 
 type ServiceInfoType {
@@ -797,6 +802,11 @@ enum OtpEnum {
 enum RouteType {
   VALID
   INVALID_NO_ROUTE_POINTS
+}
+
+type ServicePatternDistanceResult {
+  distance: Int!
+  geom: JSON!
 }
 
 # eslint-disable @graphql-eslint/no-unused-fields

--- a/abods-api/src/resolvers/index.ts
+++ b/abods-api/src/resolvers/index.ts
@@ -7,7 +7,12 @@ import corridorResolvers from "./corridorFunctions.js";
 import feedMonitoringResolvers from "./feedMonitoringFunctions.js";
 import avlResolvers from "./avlFunctions.js";
 import { Resolvers } from "../types/generated.js";
-import { DateResolver, DateTimeResolver, TimeResolver } from "graphql-scalars";
+import {
+  DateResolver,
+  DateTimeResolver,
+  TimeResolver,
+  JSONResolver,
+} from "graphql-scalars";
 import stopAnalysisResolvers from "./stopAnalysis.js";
 import dataMonitoringResolvers from "./dataMonitoringFunctions.js";
 import distancesResolver from "./distances.js";
@@ -16,6 +21,7 @@ export const customScalarResolvers: Resolvers = {
   Date: DateResolver,
   DateTime: DateTimeResolver,
   Time: TimeResolver,
+  JSON: JSONResolver,
 };
 
 const resolversArray = [

--- a/abods-api/src/resolvers/vehicleJourneyFunctions.ts
+++ b/abods-api/src/resolvers/vehicleJourneyFunctions.ts
@@ -1,15 +1,18 @@
 import { getFormattedDate, userSelectedDateAsUtc } from "../lib/dayjs.js";
+import { sql } from "kysely";
 import {
   Journey,
   JourneyResult,
   OtpEnum,
   QueryResolvers,
   Resolvers,
+  ServicePatternDistanceResult,
 } from "../types/generated.js";
 import { requireUserSession } from "./helpers.js";
 import dayjs from "dayjs";
 import { GraphQLError } from "graphql";
 import { PrismaClient } from "@prisma/client";
+import { GeoJSONLineString } from "../lib/common.js";
 
 export const findJourneys: QueryResolvers["findJourneys"] = async (
   _,
@@ -29,6 +32,7 @@ export const findJourneys: QueryResolvers["findJourneys"] = async (
         group_id: true,
         journey_pattern_description: true,
         direction: true,
+        vehicle_journey_id: true,
         expected_services: {
           select: {
             line_name: true,
@@ -55,6 +59,7 @@ export const findJourneys: QueryResolvers["findJourneys"] = async (
         operatorName:
           journey.expected_services?.expected_operator.operator_name ??
           "unknown",
+        vehicleJourneyId: journey.vehicle_journey_id,
       })),
     );
 };
@@ -193,10 +198,46 @@ export const getJourney: QueryResolvers["journey"] = async (
   return { stops, avls: avlLists.flat() };
 };
 
+export const getServicePatternDistanceGeom: QueryResolvers["getServicePatternDistanceGeom"] =
+  async (_parent, args, context): Promise<ServicePatternDistanceResult> => {
+    const result = await context.kysely
+      .selectFrom("transmodel_vehiclejourney")
+      .innerJoin(
+        "transmodel_servicepatterndistance",
+        "transmodel_vehiclejourney.service_pattern_id",
+        "transmodel_servicepatterndistance.service_pattern_id",
+      )
+      .where("transmodel_vehiclejourney.id", "=", args.vehicleJourneyId)
+      .select([
+        "transmodel_servicepatterndistance.distance",
+        sql<string>`ST_AsGeoJSON(transmodel_servicepatterndistance.geom)`.as(
+          "geom",
+        ),
+      ])
+      .executeTakeFirst();
+
+    if (!result) {
+      throw new GraphQLError(
+        `No service pattern distance found for vehicle journey ID ${args.vehicleJourneyId}`,
+        {
+          extensions: { code: "NOT_FOUND", http: { status: 404 } },
+        },
+      );
+    }
+    const parsedGeom = JSON.parse(result.geom ?? "") as GeoJSONLineString;
+    const coordinates = parsedGeom["coordinates"];
+
+    return {
+      distance: result.distance ?? 0,
+      geom: coordinates,
+    };
+  };
+
 const vehicleJourneyResolvers: Resolvers = {
   Query: {
     journey: getJourney,
     findJourneys: findJourneys,
+    getServicePatternDistanceGeom,
   },
 };
 

--- a/abods-api/src/resolvers/vehicleJourneyFunctions.ts
+++ b/abods-api/src/resolvers/vehicleJourneyFunctions.ts
@@ -225,7 +225,7 @@ export const getServicePatternDistanceGeom: QueryResolvers["getServicePatternDis
       );
     }
     const parsedGeom = JSON.parse(result.geom ?? "") as GeoJSONLineString;
-    const coordinates = parsedGeom["coordinates"];
+    const coordinates = parsedGeom?.coordinates;
 
     return {
       distance: result.distance ?? 0,

--- a/abods-api/src/types/generated.ts
+++ b/abods-api/src/types/generated.ts
@@ -17,6 +17,7 @@ export type Scalars = {
   Float: { input: number; output: number; }
   Date: { input: Date | string; output: Date | string; }
   DateTime: { input: Date | string; output: Date | string; }
+  JSON: { input: any; output: any; }
   Time: { input: Date | string; output: Date | string; }
 };
 
@@ -481,6 +482,7 @@ export type Journey = {
   serviceName: Scalars['String']['output'];
   serviceNumber: Scalars['String']['output'];
   startTime: Scalars['String']['output'];
+  vehicleJourneyId?: Maybe<Scalars['Int']['output']>;
 };
 
 export type JourneyResult = {
@@ -842,6 +844,7 @@ export type Query = {
   eventStats: Array<EventStatsType>;
   events?: Maybe<EventResponse>;
   findJourneys: Array<Journey>;
+  getServicePatternDistanceGeom: ServicePatternDistanceResult;
   headwayMetrics?: Maybe<HeadwayMetricsType>;
   invitation?: Maybe<InvitationType>;
   journey: JourneyResult;
@@ -893,6 +896,11 @@ export type QueryEventsArgs = {
 export type QueryFindJourneysArgs = {
   dateOfJourney: Scalars['String']['input'];
   lineId: Scalars['String']['input'];
+};
+
+
+export type QueryGetServicePatternDistanceGeomArgs = {
+  vehicleJourneyId: Scalars['ID']['input'];
 };
 
 
@@ -973,6 +981,12 @@ export type ServiceLinkType = {
   linkRoute?: Maybe<Scalars['String']['output']>;
   routeValidity: RouteType;
   toStop: Scalars['String']['output'];
+};
+
+export type ServicePatternDistanceResult = {
+  __typename?: 'ServicePatternDistanceResult';
+  distance: Scalars['Int']['output'];
+  geom: Scalars['JSON']['output'];
 };
 
 export type ServicePatternType = {
@@ -1295,10 +1309,12 @@ export type ResolversTypes = ResolversObject<{
   HeadwayOverviewType: ResolverTypeWrapper<Partial<HeadwayOverviewType>>;
   HeadwayTimeSeriesType: ResolverTypeWrapper<Partial<HeadwayTimeSeriesType>>;
   HistoricalStatsType: ResolverTypeWrapper<Partial<HistoricalStatsType>>;
+  ID: ResolverTypeWrapper<Partial<Scalars['ID']['output']>>;
   Int: ResolverTypeWrapper<Partial<Scalars['Int']['output']>>;
   InvitationInput: ResolverTypeWrapper<Partial<InvitationInput>>;
   InvitationResponseType: ResolverTypeWrapper<Partial<InvitationResponseType>>;
   InvitationType: ResolverTypeWrapper<Partial<InvitationType>>;
+  JSON: ResolverTypeWrapper<Partial<Scalars['JSON']['output']>>;
   Journey: ResolverTypeWrapper<Partial<Journey>>;
   JourneyResult: ResolverTypeWrapper<Partial<JourneyResult>>;
   LineType: ResolverTypeWrapper<Partial<LineType>>;
@@ -1331,6 +1347,7 @@ export type ResolversTypes = ResolversObject<{
   RouteType: ResolverTypeWrapper<Partial<RouteType>>;
   ServiceInfoType: ResolverTypeWrapper<Partial<ServiceInfoType>>;
   ServiceLinkType: ResolverTypeWrapper<Partial<ServiceLinkType>>;
+  ServicePatternDistanceResult: ResolverTypeWrapper<Partial<ServicePatternDistanceResult>>;
   ServicePatternType: ResolverTypeWrapper<Partial<ServicePatternType>>;
   ServicePerformanceFiltersInputType: ResolverTypeWrapper<Partial<ServicePerformanceFiltersInputType>>;
   ServicePerformanceInputType: ResolverTypeWrapper<Partial<ServicePerformanceInputType>>;
@@ -1404,10 +1421,12 @@ export type ResolversParentTypes = ResolversObject<{
   HeadwayOverviewType: Partial<HeadwayOverviewType>;
   HeadwayTimeSeriesType: Partial<HeadwayTimeSeriesType>;
   HistoricalStatsType: Partial<HistoricalStatsType>;
+  ID: Partial<Scalars['ID']['output']>;
   Int: Partial<Scalars['Int']['output']>;
   InvitationInput: Partial<InvitationInput>;
   InvitationResponseType: Partial<InvitationResponseType>;
   InvitationType: Partial<InvitationType>;
+  JSON: Partial<Scalars['JSON']['output']>;
   Journey: Partial<Journey>;
   JourneyResult: Partial<JourneyResult>;
   LineType: Partial<LineType>;
@@ -1436,6 +1455,7 @@ export type ResolversParentTypes = ResolversObject<{
   Query: {};
   ServiceInfoType: Partial<ServiceInfoType>;
   ServiceLinkType: Partial<ServiceLinkType>;
+  ServicePatternDistanceResult: Partial<ServicePatternDistanceResult>;
   ServicePatternType: Partial<ServicePatternType>;
   ServicePerformanceFiltersInputType: Partial<ServicePerformanceFiltersInputType>;
   ServicePerformanceInputType: Partial<ServicePerformanceInputType>;
@@ -1711,6 +1731,10 @@ export type InvitationTypeResolvers<ContextType = RequestContext, ParentType ext
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
+  name: 'JSON';
+}
+
 export type JourneyResolvers<ContextType = RequestContext, ParentType extends ResolversParentTypes['Journey'] = ResolversParentTypes['Journey']> = ResolversObject<{
   directionRef?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -1719,6 +1743,7 @@ export type JourneyResolvers<ContextType = RequestContext, ParentType extends Re
   serviceName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   serviceNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  vehicleJourneyId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1900,6 +1925,7 @@ export type QueryResolvers<ContextType = RequestContext, ParentType extends Reso
   eventStats?: Resolver<Array<ResolversTypes['EventStatsType']>, ParentType, ContextType, RequireFields<QueryEventStatsArgs, 'end' | 'operatorId' | 'start'>>;
   events?: Resolver<Maybe<ResolversTypes['EventResponse']>, ParentType, ContextType, RequireFields<QueryEventsArgs, 'end' | 'operatorId' | 'start'>>;
   findJourneys?: Resolver<Array<ResolversTypes['Journey']>, ParentType, ContextType, RequireFields<QueryFindJourneysArgs, 'dateOfJourney' | 'lineId'>>;
+  getServicePatternDistanceGeom?: Resolver<ResolversTypes['ServicePatternDistanceResult'], ParentType, ContextType, RequireFields<QueryGetServicePatternDistanceGeomArgs, 'vehicleJourneyId'>>;
   headwayMetrics?: Resolver<Maybe<ResolversTypes['HeadwayMetricsType']>, ParentType, ContextType>;
   invitation?: Resolver<Maybe<ResolversTypes['InvitationType']>, ParentType, ContextType, RequireFields<QueryInvitationArgs, 'key'>>;
   journey?: Resolver<ResolversTypes['JourneyResult'], ParentType, ContextType, RequireFields<QueryJourneyArgs, 'groupId' | 'lineId'>>;
@@ -1931,6 +1957,12 @@ export type ServiceLinkTypeResolvers<ContextType = RequestContext, ParentType ex
   linkRoute?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   routeValidity?: Resolver<ResolversTypes['RouteType'], ParentType, ContextType>;
   toStop?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ServicePatternDistanceResultResolvers<ContextType = RequestContext, ParentType extends ResolversParentTypes['ServicePatternDistanceResult'] = ResolversParentTypes['ServicePatternDistanceResult']> = ResolversObject<{
+  distance?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  geom?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -2115,6 +2147,7 @@ export type Resolvers<ContextType = RequestContext> = ResolversObject<{
   HistoricalStatsType?: HistoricalStatsTypeResolvers<ContextType>;
   InvitationResponseType?: InvitationResponseTypeResolvers<ContextType>;
   InvitationType?: InvitationTypeResolvers<ContextType>;
+  JSON?: GraphQLScalarType;
   Journey?: JourneyResolvers<ContextType>;
   JourneyResult?: JourneyResultResolvers<ContextType>;
   LineType?: LineTypeResolvers<ContextType>;
@@ -2138,6 +2171,7 @@ export type Resolvers<ContextType = RequestContext> = ResolversObject<{
   Query?: QueryResolvers<ContextType>;
   ServiceInfoType?: ServiceInfoTypeResolvers<ContextType>;
   ServiceLinkType?: ServiceLinkTypeResolvers<ContextType>;
+  ServicePatternDistanceResult?: ServicePatternDistanceResultResolvers<ContextType>;
   ServicePatternType?: ServicePatternTypeResolvers<ContextType>;
   ServicePerformanceType?: ServicePerformanceTypeResolvers<ContextType>;
   ServicePunctualityType?: ServicePunctualityTypeResolvers<ContextType>;

--- a/frontend/graphql.schema.json
+++ b/frontend/graphql.schema.json
@@ -3604,6 +3604,17 @@
       },
       {
         "kind": "SCALAR",
+        "name": "ID",
+        "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
         "isOneOf": null,
@@ -3738,6 +3749,17 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "JSON",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Journey",
         "description": null,
@@ -3847,6 +3869,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicleJourneyId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6983,6 +7017,39 @@
             "deprecationReason": null
           },
           {
+            "name": "getServicePatternDistanceGeom",
+            "description": null,
+            "args": [
+              {
+                "name": "vehicleJourneyId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ServicePatternDistanceResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "headwayMetrics",
             "description": null,
             "args": [],
@@ -7686,6 +7753,50 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ServicePatternDistanceResult",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "distance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "geom",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               }
             },

--- a/frontend/src/app/corridors/create/corridor-map/corridor-map.component.html
+++ b/frontend/src/app/corridors/create/corridor-map/corridor-map.component.html
@@ -7,11 +7,7 @@
   (mapLoad)="map = $event.target"
 >
   <mgl-control position="top-left">
-    <app-dropdown
-      identifier="map-display-menu"
-      triggerLabel="Display options"
-      [width]="200"
-    >
+    <app-dropdown identifier="map-display-menu" triggerLabel="Display options">
       <p class="govuk-body govuk-!-margin-bottom-2">
         <strong>Map view</strong>
       </p>

--- a/frontend/src/app/corridors/create/corridor-map/corridor-map.component.html
+++ b/frontend/src/app/corridors/create/corridor-map/corridor-map.component.html
@@ -10,7 +10,7 @@
     <app-dropdown
       identifier="map-display-menu"
       triggerLabel="Display options"
-      [width]="200"
+      [width]="305"
     >
       <p class="govuk-body govuk-!-margin-bottom-2">
         <strong>Map view</strong>

--- a/frontend/src/app/corridors/create/corridor-map/corridor-map.component.html
+++ b/frontend/src/app/corridors/create/corridor-map/corridor-map.component.html
@@ -10,7 +10,7 @@
     <app-dropdown
       identifier="map-display-menu"
       triggerLabel="Display options"
-      [width]="305"
+      [width]="200"
     >
       <p class="govuk-body govuk-!-margin-bottom-2">
         <strong>Map view</strong>

--- a/frontend/src/app/corridors/view/view-corridor.component.html
+++ b/frontend/src/app/corridors/view/view-corridor.component.html
@@ -119,7 +119,6 @@
             <app-dropdown
               identifier="map-display-menu"
               triggerLabel="Display options"
-              [width]="200"
             >
               <p class="govuk-body govuk-!-margin-bottom-2">
                 <strong>Map view</strong>

--- a/frontend/src/app/corridors/view/view-corridor.component.html
+++ b/frontend/src/app/corridors/view/view-corridor.component.html
@@ -119,7 +119,7 @@
             <app-dropdown
               identifier="map-display-menu"
               triggerLabel="Display options"
-              [width]="200"
+              [width]="305"
             >
               <p class="govuk-body govuk-!-margin-bottom-2">
                 <strong>Map view</strong>

--- a/frontend/src/app/corridors/view/view-corridor.component.html
+++ b/frontend/src/app/corridors/view/view-corridor.component.html
@@ -119,7 +119,7 @@
             <app-dropdown
               identifier="map-display-menu"
               triggerLabel="Display options"
-              [width]="305"
+              [width]="200"
             >
               <p class="govuk-body govuk-!-margin-bottom-2">
                 <strong>Map view</strong>

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.html
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.html
@@ -16,7 +16,7 @@
     <span>{{ triggerLabel }}</span>
     <span class="dropdown__trigger-icon"></span>
   </button>
-  <div #dropdownContent [style.width]="contentWidth">
+  <div #dropdownContent [style.width]="width">
     <ng-content></ng-content>
   </div>
 </div>

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.html
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.html
@@ -16,7 +16,7 @@
     <span>{{ triggerLabel }}</span>
     <span class="dropdown__trigger-icon"></span>
   </button>
-  <div #dropdownContent [style.width]="width">
+  <div #dropdownContent [style.width]="contentWidth">
     <ng-content></ng-content>
   </div>
 </div>

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.html
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.html
@@ -11,12 +11,11 @@
     class="govuk-body dropdown__trigger"
     [tippyName]="identifier"
     [tippyProps]="tippyProps"
-    [style.width]="triggerWidth"
   >
     <span>{{ triggerLabel }}</span>
     <span class="dropdown__trigger-icon"></span>
   </button>
-  <div #dropdownContent [style.width]="contentWidth">
+  <div #dropdownContent>
     <ng-content></ng-content>
   </div>
 </div>

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.scss
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.scss
@@ -27,6 +27,8 @@ $arrow-down-border-left: 0.3em solid transparent;
     &:not(:disabled):hover {
       background: $dropdown-background;
     }
+    box-sizing: border-box;
+    width: 305px;
   }
   &__trigger-icon {
     display: inline-block;
@@ -49,6 +51,8 @@ $arrow-down-border-left: 0.3em solid transparent;
     font-size: inherit;
     line-height: inherit;
     transition-property: transform, visibility, opacity;
+    box-sizing: border-box;
+    width: 305px;
   }
 }
 

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.ts
@@ -34,6 +34,10 @@ export class DropdownComponent implements OnInit {
     return this.width + "px";
   }
 
+  get contentWidth(): string {
+    return this.width - dropdownPadding * 2 - dropdownBorder * 2 + "px";
+  }
+
   get isOpen(): boolean {
     return (
       this.ngxTippyService.getInstance(this.identifier)?.state.isMounted ??

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.ts
@@ -30,14 +30,6 @@ export class DropdownComponent implements OnInit {
     animation: false,
   };
 
-  get triggerWidth(): string {
-    return this.width + "px";
-  }
-
-  get contentWidth(): string {
-    return this.width - dropdownPadding * 2 - dropdownBorder * 2 + "px";
-  }
-
   get isOpen(): boolean {
     return (
       this.ngxTippyService.getInstance(this.identifier)?.state.isMounted ??

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.ts
@@ -1,9 +1,6 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
 import { NgxTippyProps, NgxTippyService } from "ngx-tippy-wrapper";
 
-const dropdownPadding = 10;
-const dropdownBorder = 1;
-
 @Component({
   selector: "app-dropdown",
   templateUrl: "./dropdown.component.html",

--- a/frontend/src/app/shared/components/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/components/dropdown/dropdown.component.ts
@@ -37,10 +37,6 @@ export class DropdownComponent implements OnInit {
     return this.width + "px";
   }
 
-  get contentWidth(): string {
-    return this.width - dropdownPadding * 2 - dropdownBorder * 2 + "px";
-  }
-
   get isOpen(): boolean {
     return (
       this.ngxTippyService.getInstance(this.identifier)?.state.isMounted ??

--- a/frontend/src/app/shared/components/map-view-scheduled-route-toggle/map-view-scheduled-route-toggle.component.html
+++ b/frontend/src/app/shared/components/map-view-scheduled-route-toggle/map-view-scheduled-route-toggle.component.html
@@ -1,0 +1,18 @@
+<app-segmented-toggle
+  legend="Scheduled route view"
+  [(ngModel)]="scheduledRouteOption"
+  (ngModelChange)="onScheduledRouteChange($event)"
+>
+  <app-segmented-toggle-item
+    name="scheduled-route-show"
+    identifier="scheduled-route-show"
+    value="show"
+    label="Show"
+  ></app-segmented-toggle-item>
+  <app-segmented-toggle-item
+    name="scheduled-route-hide"
+    identifier="scheduled-route-hide"
+    value="hide"
+    label="Hide"
+  ></app-segmented-toggle-item>
+</app-segmented-toggle>

--- a/frontend/src/app/shared/components/map-view-scheduled-route-toggle/map-view-scheduled-route-toggle.component.ts
+++ b/frontend/src/app/shared/components/map-view-scheduled-route-toggle/map-view-scheduled-route-toggle.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+
+@Component({
+  selector: "app-scheduled-route-toggle",
+  templateUrl: "./map-view-scheduled-route-toggle.component.html",
+  styleUrls: ["./map-view-scheduled-route-toggle.scss"],
+  standalone: false,
+})
+export class ScheduledRouteToggleComponent {
+  @Input() visible = true;
+  @Output() visibleChange = new EventEmitter<boolean>();
+
+  scheduledRouteOption = this.visible ? "show" : "hide";
+
+  ngOnChanges() {
+    this.scheduledRouteOption = this.visible ? "show" : "hide";
+  }
+
+  onScheduledRouteChange(value: string) {
+    const visible = value === "show";
+    this.visible = visible;
+    this.visibleChange.emit(visible);
+  }
+}

--- a/frontend/src/app/shared/components/otp-legend/otp-legend.component.html
+++ b/frontend/src/app/shared/components/otp-legend/otp-legend.component.html
@@ -21,4 +21,10 @@
     </span>
     <span class="otp-legend__value otp-legend__value--muted">(> 1 minute)</span>
   </div>
+  <div class="otp-legend__item">
+    <span class="otp-legend__icon otp-legend__icon--scheduled-route"></span>
+    <span class="otp-legend__value">
+      <strong>Scheduled Route</strong>
+    </span>
+  </div>
 </div>

--- a/frontend/src/app/shared/components/otp-legend/otp-legend.component.scss
+++ b/frontend/src/app/shared/components/otp-legend/otp-legend.component.scss
@@ -22,6 +22,11 @@
     &--late {
       background-color: raas-colour("late");
     }
+    &--scheduled-route {
+      width: 24px;
+      height: 0;
+      border-top: 2px dotted #999999;
+    }
   }
 
   &__value {

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -60,6 +60,7 @@ import { GeoContextPipe } from "./mapbox/geo-context.pipe";
 import { JoinPipe } from "./pipes/join.pipe";
 import { MapRecentreButtonComponent } from "./components/map-recentre-button/map-recentre-button.component";
 import { MapViewToggleComponent } from "./components/map-view-toggle/map-view-toggle.component";
+import { ScheduledRouteToggleComponent } from "./components/map-view-scheduled-route-toggle/map-view-scheduled-route-toggle.component";
 import { DropdownComponent } from "./components/dropdown/dropdown.component";
 import { InviteUserModalComponent } from "./components/invite-user-modal/invite-user-modal.component";
 import { OtpParamRangeSliderComponent } from "./components/otp-param-range-slider/otp-param-range-slider.component";
@@ -129,6 +130,7 @@ import { DateRangePickerComponent } from "./components/date-range/date-range-pic
     JoinPipe,
     MapRecentreButtonComponent,
     MapViewToggleComponent,
+    ScheduledRouteToggleComponent,
     DropdownComponent,
     InviteUserModalComponent,
     OtpParamRangeSliderComponent,
@@ -208,6 +210,7 @@ import { DateRangePickerComponent } from "./components/date-range/date-range-pic
     JoinPipe,
     MapRecentreButtonComponent,
     MapViewToggleComponent,
+    ScheduledRouteToggleComponent,
     DropdownComponent,
     InviteUserModalComponent,
     OtpParamRangeSliderComponent,

--- a/frontend/src/app/stop-analysis/stop-analysis.component.html
+++ b/frontend/src/app/stop-analysis/stop-analysis.component.html
@@ -106,7 +106,6 @@
           <app-dropdown
             identifier="map-display-menu"
             triggerLabel="Display options"
-            [width]="200"
           >
             <p class="govuk-body govuk-!-margin-bottom-2">
               <strong>Map view</strong>

--- a/frontend/src/app/stop-analysis/stop-analysis.component.html
+++ b/frontend/src/app/stop-analysis/stop-analysis.component.html
@@ -106,7 +106,7 @@
           <app-dropdown
             identifier="map-display-menu"
             triggerLabel="Display options"
-            [width]="305"
+            [width]="200"
           >
             <p class="govuk-body govuk-!-margin-bottom-2">
               <strong>Map view</strong>

--- a/frontend/src/app/stop-analysis/stop-analysis.component.html
+++ b/frontend/src/app/stop-analysis/stop-analysis.component.html
@@ -106,7 +106,7 @@
           <app-dropdown
             identifier="map-display-menu"
             triggerLabel="Display options"
-            [width]="200"
+            [width]="305"
           >
             <p class="govuk-body govuk-!-margin-bottom-2">
               <strong>Map view</strong>

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-search/vehicle-journeys-search.service.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-search/vehicle-journeys-search.service.ts
@@ -1,12 +1,19 @@
 import { Injectable } from "@angular/core";
-import { Journey, JourneysGQL } from "../../../generated/graphql";
+import {
+  Journey,
+  JourneysGQL,
+  ServicePatternDistanceGeomGQL,
+} from "../../../generated/graphql";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { DateTime } from "luxon";
 
 @Injectable({ providedIn: "root" })
 export class VehicleJourneysSearchService {
-  constructor(private journeysGQL: JourneysGQL) {}
+  constructor(
+    private journeysGQL: JourneysGQL,
+    private servicePatternDistanceGeomGQL: ServicePatternDistanceGeomGQL,
+  ) {}
 
   fetchDayJourneys(
     dateOfJourney: string,
@@ -20,5 +27,18 @@ export class VehicleJourneysSearchService {
           .sort((a, b) => a.startTime.localeCompare(b.startTime));
       }),
     );
+  }
+
+  getServicePatternDistanceGeom(
+    vehicleJourneyId: string,
+  ): Observable<{ distance: number; geom: [number, number][] }> {
+    return this.servicePatternDistanceGeomGQL
+      .fetch({ vehicleJourneyId }, { fetchPolicy: "no-cache" })
+      .pipe(
+        map((result) => ({
+          distance: result.data.getServicePatternDistanceGeom.distance,
+          geom: result.data.getServicePatternDistanceGeom.geom,
+        })),
+      );
   }
 }

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-search/vehicle-journeys-search.service.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-search/vehicle-journeys-search.service.ts
@@ -32,13 +32,11 @@ export class VehicleJourneysSearchService {
   getServicePatternDistanceGeom(
     vehicleJourneyId: string,
   ): Observable<{ distance: number; geom: [number, number][] }> {
-    return this.servicePatternDistanceGeomGQL
-      .fetch({ vehicleJourneyId }, { fetchPolicy: "no-cache" })
-      .pipe(
-        map((result) => ({
-          distance: result.data.getServicePatternDistanceGeom.distance,
-          geom: result.data.getServicePatternDistanceGeom.geom,
-        })),
-      );
+    return this.servicePatternDistanceGeomGQL.fetch({ vehicleJourneyId }).pipe(
+      map((result) => ({
+        distance: result.data.getServicePatternDistanceGeom.distance,
+        geom: result.data.getServicePatternDistanceGeom.geom,
+      })),
+    );
   }
 }

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.html
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.html
@@ -21,6 +21,10 @@
   <span>
     <strong *ngIf="!loading; else skeletonInfo">{{ vehicleId }}</strong>
   </span>
+  <span>Service distance: </span>
+  <span>
+    <strong *ngIf="!loading; else skeletonInfo">{{ serviceDistance }}</strong>
+  </span>
 </div>
 
 <ng-template #skeletonInfo>

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.html
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.html
@@ -21,9 +21,9 @@
   <span>
     <strong *ngIf="!loading; else skeletonInfo">{{ vehicleId }}</strong>
   </span>
-  <span>Service distance: </span>
+  <span>Scheduled distance (km):</span>
   <span>
-    <strong *ngIf="!loading; else skeletonInfo">{{ serviceDistance }}</strong>
+    <strong *ngIf="!loading; else skeletonInfo">{{ serviceDistanceKm }}</strong>
   </span>
 </div>
 

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.scss
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.scss
@@ -3,7 +3,7 @@
 
 .journey-info {
   display: grid;
-  grid-template-columns: 180px 1fr;
+  grid-template-columns: 220px 1fr;
   row-gap: govuk-spacing(2);
   column-gap: govuk-spacing(2);
 }

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.ts
@@ -34,7 +34,7 @@ export class JourneyInfoComponent {
     return this.vehicleRef ?? "Unknown";
   }
 
-  get serviceDistance(): number | string {
-    return this.distance ?? "Unknown";
+  get serviceDistanceKm(): number | string {
+    return this.distance ? this.distance / 1000 : "Unknown";
   }
 }

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-info/journey-info.component.ts
@@ -12,6 +12,7 @@ export class JourneyInfoComponent {
   @Input() loading = false;
   @Input() vehicleRef: string | null = null;
   @Input() journey: Journey | null = null;
+  @Input() distance?: number | null = null;
 
   get operatorName(): string {
     return this.journey?.operatorName ?? "";
@@ -31,5 +32,9 @@ export class JourneyInfoComponent {
 
   get vehicleId(): string {
     return this.vehicleRef ?? "Unknown";
+  }
+
+  get serviceDistance(): number | string {
+    return this.distance ?? "Unknown";
   }
 }

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.html
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.html
@@ -11,11 +11,7 @@
   class="vehicle-journey__map"
 >
   <mgl-control position="top-left">
-    <app-dropdown
-      identifier="map-display-menu"
-      triggerLabel="Display options"
-      [width]="305"
-    >
+    <app-dropdown identifier="map-display-menu" triggerLabel="Display options">
       <p class="govuk-body govuk-!-margin-bottom-2">
         <strong>Map view</strong>
       </p>

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.html
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.html
@@ -14,7 +14,7 @@
     <app-dropdown
       identifier="map-display-menu"
       triggerLabel="Display options"
-      [width]="200"
+      [width]="305"
     >
       <p class="govuk-body govuk-!-margin-bottom-2">
         <strong>Map view</strong>
@@ -22,6 +22,13 @@
       <app-map-view-toggle
         (mapboxStyle)="mapboxStyle = $event"
       ></app-map-view-toggle>
+      <p class="govuk-body govuk-!-margin-bottom-2 govuk-!-margin-top-2">
+        <strong>Scheduled route view</strong>
+      </p>
+      <app-scheduled-route-toggle
+        [visible]="showScheduledRoute"
+        (visibleChange)="showScheduledRoute = $event"
+      />
     </app-dropdown>
   </mgl-control>
   <ng-container *ngIf="!loading">
@@ -192,6 +199,29 @@
       source="journey-timing-points"
       (layerMouseMove)="onStopMouseEnter($event)"
       (layerMouseLeave)="onStopMouseLeave($event)"
+    ></mgl-layer>
+    <mgl-geojson-source
+      *ngIf="showScheduledRoute && scheduledRouteLine"
+      id="scheduled-route-source"
+      [data]="scheduledRouteLine"
+      type="geojson"
+    ></mgl-geojson-source>
+
+    <mgl-layer
+      *ngIf="showScheduledRoute && scheduledRouteLine"
+      id="scheduled-route-line"
+      source="scheduled-route-source"
+      type="line"
+      [layout]="{
+        'line-join': 'round',
+        'line-cap': 'round'
+      }"
+      [paint]="{
+        'line-color': '#999999',
+        'line-width': 2,
+        'line-dasharray': [0.5, 2],
+        'line-opacity': 0.8
+      }"
     ></mgl-layer>
     <mgl-popup
       *ngIf="tooltipStop"

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.ts
@@ -90,6 +90,7 @@ export class JourneyMapComponent implements OnChanges {
   @Input() hoveredStop?: StopHoverEvent;
   @Input() loading = false;
   @Input() matchType = MatchType.Evidenced;
+  @Input() scheduledRoute?: [number, number][] | null = null;
 
   map!: Map;
   enableScaleControl = false;
@@ -101,6 +102,9 @@ export class JourneyMapComponent implements OnChanges {
   stops?: FeatureCollection<Point, VehiclePingStop>;
   timingPoints?: FeatureCollection<Point, VehiclePingStop>;
   line?: FeatureCollection<LineString, LineSegmentProps>;
+  scheduledRouteLine?: FeatureCollection<LineString>;
+  showScheduledRoute: boolean = true;
+
   pings?: FeatureCollection<Point, VehiclePing>;
 
   tooltipStop?: VehiclePingStop;
@@ -153,6 +157,15 @@ export class JourneyMapComponent implements OnChanges {
     }
     if (this.loading) {
       this.moveCounter = 0;
+    }
+
+    if (changes.scheduledRoute?.currentValue) {
+      const coords = changes.scheduledRoute.currentValue;
+      if (coords && coords.length >= 2) {
+        this.scheduledRouteLine = featureCollection([lineString(coords)]);
+      } else {
+        this.scheduledRouteLine = undefined;
+      }
     }
   }
 

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/journey-map/journey-map.component.ts
@@ -103,7 +103,7 @@ export class JourneyMapComponent implements OnChanges {
   timingPoints?: FeatureCollection<Point, VehiclePingStop>;
   line?: FeatureCollection<LineString, LineSegmentProps>;
   scheduledRouteLine?: FeatureCollection<LineString>;
-  showScheduledRoute: boolean = true;
+  showScheduledRoute = true;
 
   pings?: FeatureCollection<Point, VehiclePing>;
 

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.html
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.html
@@ -99,6 +99,7 @@
               [selectedStop]="selectedStop"
               [hoveredStop]="hoveredStop"
               [loading]="journeyInfoLoading"
+              [scheduledRoute]="servicePatternGeom"
             ></app-journey-map>
           </div>
         </div>

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.html
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.html
@@ -59,6 +59,7 @@
           [vehicleRef]="vehicleRef"
           [loading]="journeysLoading"
           [journey]="journeys[currentJourneyIndex]"
+          [distance]="servicePatternDistance"
         ></app-journey-info>
         <div class="vehicle-journeys__controls">
           <app-match-type-segmented-toggle

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.spec.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.spec.ts
@@ -17,7 +17,6 @@ import { mockVehicleStopPingFactory } from "./stop-list/stop-item/stop-item.comp
 import { StopListComponent } from "./stop-list/stop-list.component";
 
 import { VehicleJourneysViewComponent } from "./vehicle-journeys-view.component";
-import { VehicleJourneysViewService } from "./vehicle-journeys-view.service";
 import {
   VehicleJourneyInfo,
   VehicleJourneyView,

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.ts
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys-view/vehicle-journeys-view.component.ts
@@ -72,6 +72,9 @@ export class VehicleJourneysViewComponent implements OnInit, OnDestroy {
   directionRef: string | null = null;
   currentJourneyIndex = -1;
 
+  servicePatternDistance: number | null = null;
+  servicePatternGeom: [number, number][] | null = null;
+
   constructor(
     private route: ActivatedRoute,
     private service: VehicleJourneysSearchService,
@@ -199,6 +202,28 @@ export class VehicleJourneysViewComponent implements OnInit, OnDestroy {
               v.groupId === this.groupId && v.directionRef == this.directionRef,
           );
           this.journeysLoading = false;
+
+          const currentJourney = this.journeys[this.currentJourneyIndex];
+          const vehicleJourneyId = currentJourney?.vehicleJourneyId;
+          if (vehicleJourneyId) {
+            this.service
+              .getServicePatternDistanceGeom(vehicleJourneyId.toString())
+              .pipe(takeUntil(this.onDestroy$))
+              .subscribe({
+                next: ({ distance, geom }) => {
+                  this.servicePatternDistance = distance;
+                  this.servicePatternGeom = geom;
+                },
+                error: (err) => {
+                  console.error(
+                    "Failed to fetch service pattern geometry:",
+                    err,
+                  );
+                  this.servicePatternDistance = null;
+                  this.servicePatternGeom = null;
+                },
+              });
+          }
         },
         error: (err) => {
           console.log(err);

--- a/frontend/src/app/vehicle-journeys/vehicle-journeys.graphql
+++ b/frontend/src/app/vehicle-journeys/vehicle-journeys.graphql
@@ -34,5 +34,13 @@ query journeys($dateOfJourney: String!, $lineId: String!) {
     operatorName
     operatorNoc
     directionRef
+    vehicleJourneyId
+  }
+}
+
+query servicePatternDistanceGeom($vehicleJourneyId: ID!) {
+  getServicePatternDistanceGeom(vehicleJourneyId: $vehicleJourneyId) {
+    distance
+    geom
   }
 }

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -17,6 +17,7 @@ export type Scalars = {
   Float: { input: number; output: number; }
   Date: { input: string; output: string; }
   DateTime: { input: string; output: string; }
+  JSON: { input: any; output: any; }
   Time: { input: string; output: string; }
 };
 
@@ -481,6 +482,7 @@ export type Journey = {
   serviceName: Scalars['String']['output'];
   serviceNumber: Scalars['String']['output'];
   startTime: Scalars['String']['output'];
+  vehicleJourneyId?: Maybe<Scalars['Int']['output']>;
 };
 
 export type JourneyResult = {
@@ -842,6 +844,7 @@ export type Query = {
   eventStats: Array<EventStatsType>;
   events?: Maybe<EventResponse>;
   findJourneys: Array<Journey>;
+  getServicePatternDistanceGeom: ServicePatternDistanceResult;
   headwayMetrics?: Maybe<HeadwayMetricsType>;
   invitation?: Maybe<InvitationType>;
   journey: JourneyResult;
@@ -893,6 +896,11 @@ export type QueryEventsArgs = {
 export type QueryFindJourneysArgs = {
   dateOfJourney: Scalars['String']['input'];
   lineId: Scalars['String']['input'];
+};
+
+
+export type QueryGetServicePatternDistanceGeomArgs = {
+  vehicleJourneyId: Scalars['ID']['input'];
 };
 
 
@@ -973,6 +981,12 @@ export type ServiceLinkType = {
   linkRoute?: Maybe<Scalars['String']['output']>;
   routeValidity: RouteType;
   toStop: Scalars['String']['output'];
+};
+
+export type ServicePatternDistanceResult = {
+  __typename?: 'ServicePatternDistanceResult';
+  distance: Scalars['Int']['output'];
+  geom: Scalars['JSON']['output'];
 };
 
 export type ServicePatternType = {
@@ -1618,7 +1632,14 @@ export type JourneysQueryVariables = Exact<{
 }>;
 
 
-export type JourneysQuery = { __typename?: 'Query', findJourneys: Array<{ __typename?: 'Journey', groupId: string, startTime: string, serviceName: string, serviceNumber: string, operatorName: string, operatorNoc: string, directionRef?: string | null }> };
+export type JourneysQuery = { __typename?: 'Query', findJourneys: Array<{ __typename?: 'Journey', groupId: string, startTime: string, serviceName: string, serviceNumber: string, operatorName: string, operatorNoc: string, directionRef?: string | null, vehicleJourneyId?: number | null }> };
+
+export type ServicePatternDistanceGeomQueryVariables = Exact<{
+  vehicleJourneyId: Scalars['ID']['input'];
+}>;
+
+
+export type ServicePatternDistanceGeomQuery = { __typename?: 'Query', getServicePatternDistanceGeom: { __typename?: 'ServicePatternDistanceResult', distance: number, geom: any } };
 
 export type GetVersionQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3137,6 +3158,7 @@ export const JourneysDocument = gql`
     operatorName
     operatorNoc
     directionRef
+    vehicleJourneyId
   }
 }
     `;
@@ -3146,6 +3168,25 @@ export const JourneysDocument = gql`
   })
   export class JourneysGQL extends Apollo.Query<JourneysQuery, JourneysQueryVariables> {
     document = JourneysDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const ServicePatternDistanceGeomDocument = gql`
+    query servicePatternDistanceGeom($vehicleJourneyId: ID!) {
+  getServicePatternDistanceGeom(vehicleJourneyId: $vehicleJourneyId) {
+    distance
+    geom
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class ServicePatternDistanceGeomGQL extends Apollo.Query<ServicePatternDistanceGeomQuery, ServicePatternDistanceGeomQueryVariables> {
+    document = ServicePatternDistanceGeomDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);


### PR DESCRIPTION
Adding information about scheduled service distance and route to the vehicle journeys page.


### Service distance displayed as part of vehicle journey info:
<img width="1291" alt="Screenshot 2025-06-23 at 17 35 40" src="https://github.com/user-attachments/assets/1cca4700-4470-46a5-9bd7-40f43cac135b" />




### Scheduled route rendered on map, along with legend and additional dropdown option to toggle the view:
<img width="898" alt="map-with-scheduled-route" src="https://github.com/user-attachments/assets/00dafc86-4974-472e-b230-0d071062a612" />





### With scheduled route hidden:
<img width="898" alt="map-with-schedule-hidden" src="https://github.com/user-attachments/assets/6cf86aa0-6e57-466a-845a-3db19a2b2ffb" />


Note that the dropdown width has also been increased to avoid items overflowing, which they currently do in prod. This will be fixed on all pages using this component. Here's what it looked like before:

<img width="398" alt="display-options-bug" src="https://github.com/user-attachments/assets/e1246050-ba51-4a8c-99b2-c26d22de6317" />



