### PR TITLE
Get vehicle counts by distinct direction

### DIFF
--- a/abods-api/src/lib/feedMonitoring.ts
+++ b/abods-api/src/lib/feedMonitoring.ts
@@ -32,6 +32,7 @@ export const getVehicleCounts = (
     .distinct()
     .select("operator_noc")
     .select("group_id")
+    .select("direction")
     .select((eb) => [
       eb
         .exists(
@@ -47,6 +48,11 @@ export const getVehicleCounts = (
               "SiriVMPositions.operator_ref",
               "=",
               "expected_journeys.operator_noc",
+            )
+            .whereRef(
+              "SiriVMPositions.direction_ref",
+              "=",
+              "expected_journeys.direction",
             )
             .where("SiriVMPositions.recorded_at_time", ">=", startTime)
             .where("SiriVMPositions.recorded_at_time", "<", endTime),


### PR DESCRIPTION
We're currently miscounting both expected and current vehicles on the NOC feed monitoring live status page. We're counting by distinct group id, but this doesn't take direction into account. As a result, if we count the inbound and outbound service only once, when they're actually two different vehicles.

In this PR:
- We update the `getVehicleCounts` query to select by distinct `operator_noc`, `group_id`, and `direction` when counting expected vehicles
- We also consider direction when checking the vehicle location data  (SiriVMPositions) to avoid the inbound and outbound vehicles being counted as only 1 vehicle

**Important**: Before merging this PR we need to normalize the values being stored in the SiriVMPositions table, since they don't all match the `inbound` and `outbound` directions of the `expected_journeys` table