### PR TITLE
Update link to favicon

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,7 +8,7 @@
     <link
       rel="shortcut icon"
       sizes="16x16 32x32 48x48"
-      href="/assets/images/favicon.ico"
+      href="/assets/rebrand/images/favicon.ico"
       type="image/x-icon"
     />
     <meta name="theme-color" content="#1d70b8" />


### PR DESCRIPTION
Fix favicon link. Turns out chrome favors `rel=shortcut icon` over `rel=icon`, and this link hadn't been updated