### PR TITLE
feat(Quicksight): Using dynamic dashboard IDs from AWS RAM provided SSM

### DIFF
--- a/abods-api/samconfig.yaml
+++ b/abods-api/samconfig.yaml
@@ -43,6 +43,7 @@ sandbox:
         QuickSightAdminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/admin/id'
         QuickSightLtaDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/lta/id'
         QuickSightOperatorDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/operator/id'
+        QuickSightSuperadminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/superadmin/id'
         VpcId='/abods/sandbox/vpc/id'
         VpcSubnets='/abods/sandbox/vpc/subnets/private'
 
@@ -58,6 +59,7 @@ dev:
         QuickSightAdminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/admin/id'
         QuickSightLtaDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/lta/id'
         QuickSightOperatorDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/operator/id'
+        QuickSightSuperadminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/superadmin/id'
         VpcId='/abods/dev/vpc/id'
         VpcSubnets='/abods/dev/vpc/subnets/private'
 
@@ -73,6 +75,7 @@ test:
         QuickSightAdminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/admin/id'
         QuickSightLtaDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/lta/id'
         QuickSightOperatorDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/operator/id'
+        QuickSightSuperadminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/test/qs/dashboard/superadmin/id'
         VpcId='/abods/test/vpc/id'
         VpcSubnets='/abods/test/vpc/subnets/private'
 
@@ -88,6 +91,7 @@ uat:
         QuickSightAdminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/admin/id'
         QuickSightLtaDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/lta/id'
         QuickSightOperatorDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/operator/id'
+        QuickSightSuperadminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/superadmin/id'
         VpcId='/abods/uat/vpc/id'
         VpcSubnets='/abods/uat/vpc/subnets/private'
 
@@ -106,5 +110,6 @@ prod:
         QuickSightAdminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/admin/id'
         QuickSightLtaDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/lta/id'
         QuickSightOperatorDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/operator/id'
+        QuickSightSuperadminDashboardId='arn:aws:ssm:eu-west-2:228266753808:parameter/bodds/prod/qs/dashboard/superadmin/id'
         VpcId='/abods/prod/vpc/id'
         VpcSubnets='/abods/prod/vpc/subnets/private'

--- a/abods-api/template.yaml
+++ b/abods-api/template.yaml
@@ -34,6 +34,9 @@ Parameters:
   QuickSightOperatorDashboardId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: ""
+  QuickSightSuperadminDashboardId:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: ""
   RdsDbHostAddr:
     Type: String
     Default: ""
@@ -165,14 +168,9 @@ Resources:
           QUICKSIGHT_ASSUME_ROLE_ARN: !Sub "arn:aws:iam::${BodsAccountId}:role/${ProjectName}-cross-account-quicksight-role"
           QUICKSIGHT_AWS_ACCOUNT_ID: !Ref BodsAccountId
           QUICKSIGHT_ADMIN_DASHBOARD_ID: !Ref QuickSightAdminDashboardId
-          QUICKSIGHT_SUPER_ADMIN_DASHBOARD_ID:
-            !If [
-              IsNotProd,
-              "ea11eeb5-e054-49ab-9203-8220fe706695",
-              "2fe02a69-ddbc-42a8-9213-e2e64a34a94d",
-            ]
           QUICKSIGHT_LTA_DASHBOARD_ID: !Ref QuickSightLtaDashboardId
           QUICKSIGHT_OPERATOR_DASHBOARD_ID: !Ref QuickSightOperatorDashboardId
+          QUICKSIGHT_SUPER_ADMIN_DASHBOARD_ID: !Ref QuickSightSuperadminDashboardId
           QUICKSIGHT_ALLOW_USER_ACCESS_COUNT: "100"
           DATADOG_SERVICE_MONITORING_DASHBOARD: !Ref ServiceMonitoringDashboardUrl
           ABODS_FLAG_DataMonitoring: !If [IsNotProd, "true", "false"]


### PR DESCRIPTION
I really wish we'd stop hardcoding values