### PR TITLE
fix to avoid keyboard trap for accessibility

### DIFF
--- a/frontend/src/app/shared/components/date-range/date-range.component.html
+++ b/frontend/src/app/shared/components/date-range/date-range.component.html
@@ -9,7 +9,7 @@
         [hideLabel]="true"
         [ngModel]="fromToStr"
         (focussed)="openControls()"
-        (keydowned)="preventKeystroke($event)"
+        [readonly]="true"
         spaceBelow="0"
       ></gds-text-input>
       <button

--- a/frontend/src/app/shared/components/date-range/date-range.component.ts
+++ b/frontend/src/app/shared/components/date-range/date-range.component.ts
@@ -87,11 +87,6 @@ export class DateRangeComponent implements ControlValueAccessor {
     this.open = !this.open;
   }
 
-  preventKeystroke(event: Event) {
-    event.returnValue = false;
-    event.preventDefault();
-  }
-
   pickDateRange(value: FromTo) {
     this.onChange({ ...value, preset: Preset.Custom });
   }


### PR DESCRIPTION
Fix addresses an issue where an input field would deny shifting focus based on keyboard input which would be against accessibility principles