### PR TITLE
DBODS-1039: case-sensitive email

### DIFF
--- a/abods-api/src/resolvers/userFunctions.ts
+++ b/abods-api/src/resolvers/userFunctions.ts
@@ -130,7 +130,11 @@ export const loginUser: MutationResolvers["login"] = async (
         "bods_userorganisation.organisation_id",
       )
       .innerJoin("login_details", "login_details.user_id", "bods_user.id")
-      .where("bods_user.email", "=", args.username)
+      .where(
+        (eb) => eb.fn("lower", [eb.ref("bods_user.email")]),
+        "=",
+        args.username.toLowerCase(),
+      )
       .where("bods_user.is_active", "=", true)
       .distinctOn(["bods_user.id", "bods_user.password"])
       .select([


### PR DESCRIPTION
Make login email comparison case‑insensitive so users can authenticate regardless of input letter case