### PR TITLE
New bucket to host abods v2 nextjs frontend assets

### DIFF
--- a/abods-api/template.yaml
+++ b/abods-api/template.yaml
@@ -291,6 +291,26 @@ Resources:
         - Key: backup_plan
           Value: bods-backup
 
+  FrontendBucketV2:
+    Type: AWS::S3::Bucket
+    Condition: IsNotLocal
+    Properties:
+      # checkov:skip=CKV_AWS_18:Just contains front end resources, so not concerned about access logs
+      # checkov:skip=CKV_AWS_21:No need for versioning, we should re-run CI to recreate anything
+      BucketName: !Sub "${ProjectName}-${Environment}-deployment-frontend-v2"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: !Sub "${VersioningConfiguration}"
+      Tags:
+        - Key: backup
+          Value: !Sub "${BackupEnabled}"
+        - Key: backup_plan
+          Value: bods-backup
+
   FrontendBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Condition: IsNotLocal
@@ -307,6 +327,28 @@ Resources:
             Resource: !Sub
               - "arn:aws:s3:::${Bucket}/*"
               - Bucket: !Ref FrontendBucket
+            Condition:
+              StringEquals:
+                aws:SourceArn: !Sub
+                  - "arn:aws:cloudfront::${AWS::AccountId}:distribution/${Distribution}"
+                  - Distribution: !Ref CloudFrontDistribution
+
+  FrontendBucketV2Policy:
+    Type: AWS::S3::BucketPolicy
+    Condition: IsNotLocal
+    Properties:
+      Bucket: !Ref FrontendBucketV2
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowCloudFrontServicePrincipal
+            Effect: Allow
+            Principal:
+              Service: "cloudfront.amazonaws.com"
+            Action: "s3:GetObject"
+            Resource: !Sub
+              - "arn:aws:s3:::${Bucket}/*"
+              - Bucket: !Ref FrontendBucketV2
             Condition:
               StringEquals:
                 aws:SourceArn: !Sub
@@ -333,6 +375,11 @@ Resources:
             OriginAccessControlId: !GetAtt CloudFrontOriginAccessControl.Id
             S3OriginConfig:
               OriginAccessIdentity: ""
+          - Id: frontendBucketV2
+            DomainName: !GetAtt FrontendBucketV2.RegionalDomainName
+            OriginAccessControlId: !GetAtt CloudFrontOriginAccessControl.Id
+            S3OriginConfig:
+              OriginAccessIdentity: ""
           - Id: backendApi
             DomainName: !Sub "${GraphQlApi}.execute-api.${AWS::Region}.amazonaws.com"
             OriginPath: !Sub "/${Environment}"
@@ -349,6 +396,15 @@ Resources:
           OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf # Managed-CORS-S3Origin
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimised
         CacheBehaviors:
+          - TargetOriginId: frontendBucketV2
+            PathPattern: "/v2/*"
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf # Managed-CORS-S3Origin
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimised
           - TargetOriginId: frontendBucket
             PathPattern: "/freshdesk/*"
             ViewerProtocolPolicy: redirect-to-https
@@ -427,3 +483,6 @@ Outputs:
   FrontendBucketName:
     Description: "Name of Frontend S3 Bucket"
     Value: !Sub "s3://${FrontendBucket}"
+  FrontendBucketV2Name:
+    Description: "Name of Frontend V2 S3 Bucket"
+    Value: !Sub "s3://${FrontendBucketV2}"


### PR DESCRIPTION
This pull request updates the CloudFormation template to add support for a new versioned frontend S3 bucket and integrate it with CloudFront. The main changes include provisioning the new `FrontendBucketV2`, setting up its access policy, configuring it as a CloudFront origin, and routing `/v2/*` requests to this new bucket.

**Infrastructure additions and updates:**

* Added a new S3 bucket resource `FrontendBucketV2` with appropriate security settings and tags to store version 2 frontend assets.
* Created a new bucket policy `FrontendBucketV2Policy` to allow CloudFront to access objects in `FrontendBucketV2`.

**CloudFront integration:**

* Added `FrontendBucketV2` as a new origin in the `CloudFrontDistribution` configuration.
* Configured a new cache behavior in CloudFront to route `/v2/*` paths to `FrontendBucketV2` with security and caching policies.

**Outputs:**

* Added a new output `FrontendBucketV2Name` to expose the name of the new S3 bucket.