### PR TITLE
DBODS-1662: Set static pages to be unauthenticated

### DIFF
--- a/abods-api/template.yaml
+++ b/abods-api/template.yaml
@@ -356,6 +356,36 @@ Resources:
                   - "arn:aws:cloudfront::${AWS::AccountId}:distribution/${Distribution}"
                   - Distribution: !Ref CloudFrontDistributionV2
 
+  CloudFrontRewriteFunctionV2:
+    Type: AWS::CloudFront::Function
+    Condition: IsNonProd
+    Properties:
+      Name: !Sub "${ProjectName}-${Environment}-rewrite-v2"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: Rewrite extensionless frontend routes to static index documents
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+          var request = event.request;
+          var uri = request.uri;
+
+          if (!uri || uri.indexOf('/api/') === 0) {
+            return request;
+          }
+
+          if (uri.endsWith('/')) {
+            request.uri = uri + 'index.html';
+            return request;
+          }
+
+          if (uri.indexOf('.') === -1) {
+            request.uri = uri + '/index.html';
+          }
+
+          return request;
+        }
+
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Condition: IsNotLocal
@@ -461,6 +491,9 @@ Resources:
             - OPTIONS
           OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf # Managed-CORS-S3Origin
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimised
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt CloudFrontRewriteFunctionV2.FunctionARN
         CacheBehaviors:
           - TargetOriginId: backendApi
             PathPattern: "/api/*"

--- a/frontend-two/components/form/PasswordInput.tsx
+++ b/frontend-two/components/form/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, KeyboardEvent, useState } from "react";
 import { ErrorInfo } from "@/types";
 
 interface PasswordInputProps<T> {
@@ -44,6 +44,13 @@ export const PasswordInput = <T,>({
     setShowPassword(false);
   };
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      setShowPassword((current) => !current);
+    }
+  };
+
   return (
     <div
       className={
@@ -83,9 +90,8 @@ export const PasswordInput = <T,>({
           onMouseLeave={handleMouseLeave}
           onTouchStart={handleMouseDown}
           onTouchEnd={handleMouseUp}
+          onKeyDown={handleKeyDown}
           aria-controls={inputId}
-          aria-hidden="true"
-          tabIndex={-1}
           aria-label={`${showPassword ? "Hide" : "Show"} password`}
         >
           {showPassword ? "Hide" : "Show"}

--- a/frontend-two/components/layout/BaseLayout.tsx
+++ b/frontend-two/components/layout/BaseLayout.tsx
@@ -18,6 +18,8 @@ interface BaseLayoutProps {
   errors?: ErrorInfo[];
 }
 
+const PUBLIC_ROUTES = ["/login", "/accessibility", "/cookies", "/privacy-policy"];
+
 export const BaseLayout = ({
   title,
   description,
@@ -26,8 +28,8 @@ export const BaseLayout = ({
 }: BaseLayoutProps) => {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
-  const showAuthenticatedLayout =
-    isAuthenticated && router.pathname !== "/login";
+  const isPublicRoute = PUBLIC_ROUTES.includes(router.pathname);
+  const showAuthenticatedLayout = isAuthenticated && !isPublicRoute;
   const pageTitle = buildTitle(errors, title);
 
   return (

--- a/frontend-two/components/layout/BaseLayout.tsx
+++ b/frontend-two/components/layout/BaseLayout.tsx
@@ -10,6 +10,7 @@ import { SkipLinks } from "@/components/layout/SkipLinks";
 import { useAuth } from "@/hooks/useAuth";
 import { ErrorInfo } from "@/types";
 import { buildTitle } from "@/utils/errors";
+import { normalizePathname } from "@/utils/path";
 
 interface BaseLayoutProps {
   title: string;
@@ -17,7 +18,6 @@ interface BaseLayoutProps {
   children: ReactNode;
   errors?: ErrorInfo[];
 }
-
 const PUBLIC_ROUTES = ["/login", "/accessibility", "/cookies", "/privacy-policy"];
 
 export const BaseLayout = ({
@@ -28,7 +28,10 @@ export const BaseLayout = ({
 }: BaseLayoutProps) => {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
-  const isPublicRoute = PUBLIC_ROUTES.includes(router.pathname);
+  const normalizedPath = normalizePathname(router.asPath);
+  const isPublicRoute = PUBLIC_ROUTES.some((route) =>
+    normalizedPath === route || normalizedPath.endsWith(route),
+  );
   const showAuthenticatedLayout = isAuthenticated && !isPublicRoute;
   const pageTitle = buildTitle(errors, title);
 

--- a/frontend-two/components/layout/BaseLayout.tsx
+++ b/frontend-two/components/layout/BaseLayout.tsx
@@ -10,7 +10,6 @@ import { SkipLinks } from "@/components/layout/SkipLinks";
 import { useAuth } from "@/hooks/useAuth";
 import { ErrorInfo } from "@/types";
 import { buildTitle } from "@/utils/errors";
-import { normalizePathname } from "@/utils/path";
 
 interface BaseLayoutProps {
   title: string;
@@ -28,7 +27,7 @@ export const BaseLayout = ({
 }: BaseLayoutProps) => {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
-  const normalizedPath = normalizePathname(router.asPath);
+  const normalizedPath = router.asPath.split("?")[0].replace(/\/+$/, "") || "/";
   const isPublicRoute = PUBLIC_ROUTES.some((route) =>
     normalizedPath === route || normalizedPath.endsWith(route),
   );

--- a/frontend-two/components/layout/CookieBanner.tsx
+++ b/frontend-two/components/layout/CookieBanner.tsx
@@ -88,7 +88,7 @@ export const CookieBanner = () => {
           >
             Reject analytics cookies
           </button>
-          <Link className="govuk-link" href="/cookies">
+          <Link className="govuk-link" href="/cookies/">
             View cookies
           </Link>
         </div>

--- a/frontend-two/components/layout/Footer.tsx
+++ b/frontend-two/components/layout/Footer.tsx
@@ -13,17 +13,23 @@ export const Footer = () => {
             <h2 className="govuk-visually-hidden">Support links</h2>
             <ul className="govuk-footer__inline-list">
               <li className="govuk-footer__inline-list-item">
-                <Link className="govuk-footer__link" href="/cookies">
+                <Link className="govuk-footer__link" href="/cookies/">
                   Cookies
                 </Link>
               </li>
               <li className="govuk-footer__inline-list-item">
-                <Link className="govuk-footer__link" href="/privacy-policy">
+                <Link
+                  className="govuk-footer__link"
+                  href="/privacy-policy/"
+                >
                   Privacy
                 </Link>
               </li>
               <li className="govuk-footer__inline-list-item">
-                <Link className="govuk-footer__link" href="/accessibility">
+                <Link
+                  className="govuk-footer__link"
+                  href="/accessibility/"
+                >
                   Accessibility
                 </Link>
               </li>

--- a/frontend-two/utils/path.ts
+++ b/frontend-two/utils/path.ts
@@ -1,0 +1,9 @@
+export const stripTrailingSlashes = (path: string): string => {
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+};
+
+export const normalizePathname = (urlPath: string): string => {
+  const [pathOnly] = urlPath.split(/[?#]/, 1);
+  return stripTrailingSlashes(pathOnly || "/");
+};

--- a/frontend-two/utils/path.ts
+++ b/frontend-two/utils/path.ts
@@ -1,9 +1,0 @@
-export const stripTrailingSlashes = (path: string): string => {
-  const trimmed = path.replace(/\/+$/, "");
-  return trimmed === "" ? "/" : trimmed;
-};
-
-export const normalizePathname = (urlPath: string): string => {
-  const [pathOnly] = urlPath.split(/[?#]/, 1);
-  return stripTrailingSlashes(pathOnly || "/");
-};


### PR DESCRIPTION
Issue:

- Client Side Navigation is fine as will be resolved by nextjs
- When clicking open static page links in new tab the request is routed via cloudfront. Cloudfront cannot find a /accessibility page (from the request) and thus redirects to the default login page. 

Change: 
- Makes Explicit which pages are public
- Adds rewrite behaviour function to cloudfront ([tested in sandbox account](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home#/functions/RewritePathEndingsIndexHTMLV2))