### PR TITLE
SortableTable + SortedPaginatedTable + Stop Analysis Tweakes

### DIFF
--- a/frontend-two/__tests__/components/shared/LocationLookupField.test.tsx
+++ b/frontend-two/__tests__/components/shared/LocationLookupField.test.tsx
@@ -29,7 +29,7 @@ describe("LocationLookupField", () => {
         features: [
           {
             id: "place.1",
-            place_name: "Test location",
+            text: "Test location",
             center: [-1, 53],
             bbox: [-1.1, 52.9, -0.9, 53.1],
           },

--- a/frontend-two/__tests__/components/stop-analysis/StopAnalysisTable.test.tsx
+++ b/frontend-two/__tests__/components/stop-analysis/StopAnalysisTable.test.tsx
@@ -90,7 +90,6 @@ describe("StopAnalysisTable", () => {
     render(
       <StopAnalysisTable
         data={[baseRow]}
-        loading={false}
         errored={false}
         directions={["Inbound", "Outbound"]}
         onDirectionsChange={vi.fn()}
@@ -122,7 +121,6 @@ describe("StopAnalysisTable", () => {
     render(
       <StopAnalysisTable
         data={[baseRow]}
-        loading={false}
         errored={false}
         directions={["Inbound", "Outbound"]}
         onDirectionsChange={vi.fn()}
@@ -175,7 +173,6 @@ describe("StopAnalysisTable", () => {
     render(
       <StopAnalysisTable
         data={[baseRow]}
-        loading={false}
         errored={false}
         directions={["Inbound", "Outbound"]}
         onDirectionsChange={vi.fn()}
@@ -200,7 +197,6 @@ describe("StopAnalysisTable", () => {
       return (
         <StopAnalysisTable
           data={[baseRow]}
-          loading={false}
           errored={false}
           directions={directions}
           onDirectionsChange={setDirections}
@@ -230,7 +226,6 @@ describe("StopAnalysisTable", () => {
       return (
         <StopAnalysisTable
           data={[baseRow]}
-          loading={false}
           errored={false}
           directions={directions}
           onDirectionsChange={setDirections}

--- a/frontend-two/__tests__/components/stop-analysis/StopAnalysisTable.test.tsx
+++ b/frontend-two/__tests__/components/stop-analysis/StopAnalysisTable.test.tsx
@@ -132,6 +132,11 @@ describe("StopAnalysisTable", () => {
 
     expect(screen.getByTestId("table-head")).toHaveTextContent("Scheduled");
     expect(screen.getByTestId("table-head")).toHaveTextContent("Recorded");
+    expect(screen.getByTestId("table-head")).toHaveTextContent("Name");
+    expect(screen.getByTestId("table-head")).toHaveTextContent("Direction");
+    expect(screen.getByTestId("table-head")).toHaveTextContent(
+      "Av. Scheduled Travel Time",
+    );
 
     await user.click(screen.getByRole("button", { name: "Display options" }));
 
@@ -140,33 +145,29 @@ describe("StopAnalysisTable", () => {
       within(dialog).getByRole("checkbox", { name: "NAPTAN" }),
     ).toBeDisabled();
 
-    await user.click(
-      within(dialog).getByRole("checkbox", { name: "Scheduled" }),
-    );
+    await user.click(within(dialog).getByRole("checkbox", { name: "Name" }));
     await user.click(within(dialog).getByRole("button", { name: "Show all" }));
     expect(
-      within(dialog).getByRole("checkbox", { name: "Scheduled" }),
+      within(dialog).getByRole("checkbox", { name: "Name" }),
     ).toBeChecked();
 
-    await user.click(
-      within(dialog).getByRole("checkbox", { name: "Scheduled" }),
-    );
+    await user.click(within(dialog).getByRole("checkbox", { name: "Name" }));
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
 
-    expect(screen.getByTestId("table-head")).toHaveTextContent("Scheduled");
+    expect(screen.getByTestId("table-head")).toHaveTextContent("Name");
 
     await user.click(screen.getByRole("button", { name: "Display options" }));
     const updatedDialog = screen.getByRole("dialog", {
       name: "Display options",
     });
     await user.click(
-      within(updatedDialog).getByRole("checkbox", { name: "Scheduled" }),
+      within(updatedDialog).getByRole("checkbox", { name: "Name" }),
     );
     await user.click(
       within(updatedDialog).getByRole("button", { name: "Update" }),
     );
 
-    expect(screen.getByTestId("table-head")).not.toHaveTextContent("Scheduled");
+    expect(screen.getByTestId("table-head")).not.toHaveTextContent("Name");
     expect(screen.getByTestId("table-head")).toHaveTextContent("Recorded");
   });
 

--- a/frontend-two/__tests__/pages/stop-analysis.test.tsx
+++ b/frontend-two/__tests__/pages/stop-analysis.test.tsx
@@ -157,6 +157,22 @@ describe("StopAnalysisPage", () => {
     expect(table).toHaveAttribute("data-directions", "Inbound,Outbound");
   });
 
+  it("replaces the table with loading dots while stop data is loading", () => {
+    mockRouterQuery = {
+      minLatitude: "51.0",
+      maxLatitude: "51.1",
+      minLongitude: "-1.2",
+      maxLongitude: "-1.1",
+    };
+    mockFetchStopAnalysis.mockReturnValue(new Promise(() => {}));
+
+    render(<StopAnalysisPage />);
+
+    expect(screen.queryByTestId("stop-analysis-table")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
   it("renders base layout wrapper", () => {
     render(<StopAnalysisPage />);
     expect(screen.getByTestId("base-layout")).toBeInTheDocument();

--- a/frontend-two/components/shared/LocationLookupField.tsx
+++ b/frontend-two/components/shared/LocationLookupField.tsx
@@ -124,7 +124,6 @@ export const LocationLookupField = ({
       </label>
       <div className="stop-analysis-filters__location-search">
         <div className="stop-analysis-filters__location-input-wrap">
-            onBlur={() => {
           {selectedOption ? (
             <div
               className="govuk-input stop-analysis-filters__location-input stop-analysis-filters__location-selected"

--- a/frontend-two/components/shared/LocationLookupField.tsx
+++ b/frontend-two/components/shared/LocationLookupField.tsx
@@ -1,8 +1,20 @@
 import { useEffect, useState } from "react";
+import {
+  buildLocationContext,
+  buildLocationSearchTypes,
+  type GeocodingFeature,
+} from "@/types/mapbox";
+
+const LOCATION_SEARCH_TYPES = buildLocationSearchTypes([
+  "poi",
+  "region",
+  "country",
+]);
 
 export interface LocationLookupSelection {
   id: string;
   label: string;
+  context?: string;
   center?: [number, number];
   bbox?: [number, number, number, number];
 }
@@ -47,7 +59,7 @@ export const LocationLookupField = ({
         setLoading(true);
         const encodedQuery = encodeURIComponent(value.trim());
         const response = await fetch(
-          `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodedQuery}.json?country=gb&autocomplete=true&limit=5&types=place,postcode,address&access_token=${mapboxToken}`,
+          `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodedQuery}.json?country=gb&autocomplete=true&limit=5&types=${LOCATION_SEARCH_TYPES}&access_token=${mapboxToken}`,
           { signal: controller.signal },
         );
 
@@ -57,18 +69,14 @@ export const LocationLookupField = ({
         }
 
         const payload = (await response.json()) as {
-          features?: Array<{
-            id: string;
-            place_name: string;
-            center?: [number, number];
-            bbox?: [number, number, number, number];
-          }>;
+          features?: GeocodingFeature[];
         };
 
         setOptions(
           (payload.features ?? []).map((feature) => ({
             id: feature.id,
-            label: feature.place_name,
+            label: feature.text,
+            context: buildLocationContext(feature.context ?? []),
             center: feature.center,
             bbox: feature.bbox,
           })),
@@ -147,6 +155,11 @@ export const LocationLookupField = ({
                   }}
                 >
                   {option.label}
+                  {option.context && (
+                    <span className="stop-analysis-filters__location-option-context">
+                      {option.context}
+                    </span>
+                  )}
                 </button>
               ))}
           </div>

--- a/frontend-two/components/shared/LocationLookupField.tsx
+++ b/frontend-two/components/shared/LocationLookupField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   buildLocationContext,
   buildLocationSearchTypes,
@@ -45,6 +45,27 @@ export const LocationLookupField = ({
   const [open, setOpen] = useState(false);
   const [options, setOptions] = useState<LocationLookupSelection[]>([]);
   const [loading, setLoading] = useState(false);
+  const [selectedOption, setSelectedOption] =
+    useState<LocationLookupSelection | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!value) setSelectedOption(null);
+  }, [value]);
+
+  const clearSelection = (initialValue: string) => {
+    setSelectedOption(null);
+    onValueChange(initialValue);
+    setOpen(true);
+    window.setTimeout(() => {
+      const input = inputRef.current;
+      if (input) {
+        input.focus();
+        input.setSelectionRange(initialValue.length, initialValue.length);
+      }
+    }, 0);
+  };
 
   useEffect(() => {
     if (disabled || !mapboxToken || value.trim().length < 3) {
@@ -103,30 +124,80 @@ export const LocationLookupField = ({
       </label>
       <div className="stop-analysis-filters__location-search">
         <div className="stop-analysis-filters__location-input-wrap">
-          <input
-            id={id}
-            className="govuk-input stop-analysis-filters__location-input"
-            type="text"
-            value={value}
-            onChange={(event) => {
-              onValueChange(event.target.value);
-              setOpen(true);
-            }}
-            onFocus={() => setOpen(true)}
             onBlur={() => {
-              window.setTimeout(() => setOpen(false), 120);
-            }}
-            placeholder={placeholder}
-            aria-label={label}
-            disabled={disabled}
-          />
+          {selectedOption ? (
+            <div
+              className="govuk-input stop-analysis-filters__location-input stop-analysis-filters__location-selected"
+            >
+              <span className="stop-analysis-filters__location-selected-text">
+                <span>{selectedOption.label}</span>
+                {selectedOption.context && (
+                  <span className="stop-analysis-filters__location-option-context">
+                    {selectedOption.context}
+                  </span>
+                )}
+              </span>
+              <input
+                ref={overlayRef}
+                id={id}
+                className="stop-analysis-filters__location-overlay-input"
+                type="text"
+                value=""
+                aria-label={selectedOption.label}
+                onChange={(e) => clearSelection(e.target.value)}
+                onFocus={() => setOpen(true)}
+                onBlur={() => {
+                  window.setTimeout(() => setOpen(false), 120);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setOpen(false);
+                  else if (e.key === "Backspace" || e.key === "Delete") clearSelection("");
+                }}
+              />
+            </div>
+          ) : (
+            <input
+              ref={inputRef}
+              id={id}
+              className="govuk-input stop-analysis-filters__location-input"
+              type="text"
+              value={value}
+              onChange={(event) => {
+                onValueChange(event.target.value);
+                setOpen(true);
+              }}
+              onFocus={() => setOpen(true)}
+              onBlur={() => {
+                window.setTimeout(() => setOpen(false), 120);
+              }}
+              placeholder={placeholder}
+              aria-label={label}
+              disabled={disabled}
+            />
+          )}
+          {(selectedOption || value) && (
+            <button
+              type="button"
+              className="stop-analysis-filters__location-clear"
+              aria-label="Clear location"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                setSelectedOption(null);
+                onValueChange("");
+                setOpen(false);
+                window.setTimeout(() => inputRef.current?.focus(), 0);
+              }}
+            >
+              ×
+            </button>
+          )}
           <span
             className={`stop-analysis-filters__location-chevron${open ? " stop-analysis-filters__location-chevron--open" : ""}`}
             aria-hidden="true"
           />
         </div>
 
-        {open && !disabled && (value.trim().length === 0 || hasResults) && (
+        {open && !disabled && (selectedOption || value.trim().length === 0 || hasResults) && (
           <div
             className="stop-analysis-filters__location-results"
             role="listbox"
@@ -149,6 +220,7 @@ export const LocationLookupField = ({
                   type="button"
                   className="stop-analysis-filters__location-option"
                   onClick={() => {
+                    setSelectedOption(option);
                     onValueChange(option.label);
                     setOpen(false);
                     onSelect?.(option);

--- a/frontend-two/components/shared/LocationLookupField.tsx
+++ b/frontend-two/components/shared/LocationLookupField.tsx
@@ -125,9 +125,7 @@ export const LocationLookupField = ({
       <div className="stop-analysis-filters__location-search">
         <div className="stop-analysis-filters__location-input-wrap">
           {selectedOption ? (
-            <div
-              className="govuk-input stop-analysis-filters__location-input stop-analysis-filters__location-selected"
-            >
+            <div className="govuk-input stop-analysis-filters__location-input stop-analysis-filters__location-selected">
               <span className="stop-analysis-filters__location-selected-text">
                 <span>{selectedOption.label}</span>
                 {selectedOption.context && (
@@ -150,7 +148,8 @@ export const LocationLookupField = ({
                 }}
                 onKeyDown={(e) => {
                   if (e.key === "Escape") setOpen(false);
-                  else if (e.key === "Backspace" || e.key === "Delete") clearSelection("");
+                  else if (e.key === "Backspace" || e.key === "Delete")
+                    clearSelection("");
                 }}
               />
             </div>
@@ -196,45 +195,47 @@ export const LocationLookupField = ({
           />
         </div>
 
-        {open && !disabled && (selectedOption || value.trim().length === 0 || hasResults) && (
-          <div
-            className="stop-analysis-filters__location-results"
-            role="listbox"
-          >
-            {value.trim().length === 0 && (
-              <div className="stop-analysis-filters__location-hint">
-                Type to search
-              </div>
-            )}
-            {value.trim().length > 0 && loading && (
-              <div className="stop-analysis-filters__location-loading">
-                Searching...
-              </div>
-            )}
-            {value.trim().length > 0 &&
-              !loading &&
-              options.map((option) => (
-                <button
-                  key={option.id}
-                  type="button"
-                  className="stop-analysis-filters__location-option"
-                  onClick={() => {
-                    setSelectedOption(option);
-                    onValueChange(option.label);
-                    setOpen(false);
-                    onSelect?.(option);
-                  }}
-                >
-                  {option.label}
-                  {option.context && (
-                    <span className="stop-analysis-filters__location-option-context">
-                      {option.context}
-                    </span>
-                  )}
-                </button>
-              ))}
-          </div>
-        )}
+        {open &&
+          !disabled &&
+          (selectedOption || value.trim().length === 0 || hasResults) && (
+            <div
+              className="stop-analysis-filters__location-results"
+              role="listbox"
+            >
+              {value.trim().length === 0 && (
+                <div className="stop-analysis-filters__location-hint">
+                  Type to search
+                </div>
+              )}
+              {value.trim().length > 0 && loading && (
+                <div className="stop-analysis-filters__location-loading">
+                  Searching...
+                </div>
+              )}
+              {value.trim().length > 0 &&
+                !loading &&
+                options.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className="stop-analysis-filters__location-option"
+                    onClick={() => {
+                      setSelectedOption(option);
+                      onValueChange(option.label);
+                      setOpen(false);
+                      onSelect?.(option);
+                    }}
+                  >
+                    {option.label}
+                    {option.context && (
+                      <span className="stop-analysis-filters__location-option-context">
+                        {option.context}
+                      </span>
+                    )}
+                  </button>
+                ))}
+            </div>
+          )}
       </div>
     </div>
   );

--- a/frontend-two/components/shared/PagingPanel.tsx
+++ b/frontend-two/components/shared/PagingPanel.tsx
@@ -75,7 +75,7 @@ export const PagingPanel = ({
         Showing {firstRow} - {lastRow} of {rowCount} {pluralNoun}
       </span>
       {totalPages > 1 && (
-        <nav className="flex items-baseline gap-1 govuk-body govuk-!-margin-bottom-0">
+        <nav className="flex items-baseline gap-[10px] govuk-body govuk-!-margin-bottom-0">
           {currentPage > 0 && (
             <a
               href="#"

--- a/frontend-two/components/shared/PagingPanel.tsx
+++ b/frontend-two/components/shared/PagingPanel.tsx
@@ -1,21 +1,54 @@
-import dynamic from "next/dynamic";
-import { MemoryRouter } from "react-router-dom";
-
-const Pagination = dynamic(
-  () =>
-    import("kainossoftwareltd-govuk-react-kainos").then(
-      (mod) => mod.Pagination,
-    ),
-  { ssr: false },
-);
-
 interface PagingPanelProps {
   currentPage: number;
   totalPages: number;
   pageSize: number;
   rowCount: number;
   noun?: string;
+  alignment?: "left" | "right";
   onPageChange: (page: number) => void;
+}
+
+const MINIMUM_PAGES = 8;
+const STICKY_THRESHOLD = 4;
+const PAGES_STICKY = 5;
+const PAGES_MIDDLE = 3;
+
+function getPageNumbers(
+  currentPage: number,
+  totalPages: number,
+): (number | "...")[] {
+  // currentPage is 1-based
+  if (totalPages <= MINIMUM_PAGES) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const current0 = currentPage - 1;
+  const stickToStart = current0 < STICKY_THRESHOLD;
+  const stickToEnd = totalPages - current0 - 1 < STICKY_THRESHOLD;
+
+  const numPages = stickToStart || stickToEnd ? PAGES_STICKY : PAGES_MIDDLE;
+  const offset = stickToStart
+    ? 0
+    : stickToEnd
+      ? totalPages - STICKY_THRESHOLD - 1
+      : current0 - Math.floor(PAGES_MIDDLE / 2);
+
+  const windowPages = Array.from(
+    { length: numPages },
+    (_, i) => offset + i + 1,
+  );
+
+  const result: (number | "...")[] = [];
+  if (!stickToStart) {
+    result.push(1);
+    result.push("...");
+  }
+  result.push(...windowPages);
+  if (!stickToEnd) {
+    result.push("...");
+    result.push(totalPages);
+  }
+  return result;
 }
 
 export const PagingPanel = ({
@@ -24,6 +57,7 @@ export const PagingPanel = ({
   pageSize,
   rowCount,
   noun = "row",
+  alignment = "right",
   onPageChange,
 }: PagingPanelProps) => {
   if (totalPages === 0 || rowCount === 0) return null;
@@ -31,25 +65,69 @@ export const PagingPanel = ({
   const firstRow = pageSize * currentPage + 1;
   const lastRow = Math.min(firstRow + pageSize - 1, rowCount);
   const pluralNoun = `${noun}${rowCount > 1 ? "s" : ""}`;
-  const paginationCurrentPage = currentPage + 1;
+  const pages = getPageNumbers(currentPage + 1, totalPages);
 
   return (
-    <div className="flex justify-end">
-      <div className="w-full flex items-center justify-between gap-8">
-        <span className="govuk-body">
-          Showing {firstRow} - {lastRow} of {rowCount} {pluralNoun}
-        </span>
-        {totalPages > 1 && (
-          <MemoryRouter>
-            <Pagination
-              currentPage={paginationCurrentPage}
-              totalPages={totalPages}
-              onPageChange={(page) => onPageChange(Math.max(0, page - 1))}
-              pathFunc={() => "#"}
-            />
-          </MemoryRouter>
-        )}
-      </div>
+    <div
+      className={`paging-panel flex w-full items-baseline gap-6 ${alignment === "left" ? "justify-start" : "justify-end"}`}
+    >
+      <span className="govuk-body govuk-!-margin-bottom-0">
+        Showing {firstRow} - {lastRow} of {rowCount} {pluralNoun}
+      </span>
+      {totalPages > 1 && (
+        <nav className="flex items-baseline gap-1 govuk-body govuk-!-margin-bottom-0">
+          {currentPage > 0 && (
+            <a
+              href="#"
+              className="govuk-link govuk-!-margin-bottom-0"
+              onClick={(e) => {
+                e.preventDefault();
+                onPageChange(currentPage - 1);
+              }}
+            >
+              « Prev
+            </a>
+          )}
+          {pages.map((page, i) =>
+            page === "..." ? (
+              <span
+                key={`ellipsis-${i}`}
+                className="govuk-body govuk-!-margin-bottom-0"
+              >
+                ...
+              </span>
+            ) : page === currentPage + 1 ? (
+              <strong key={page} className="govuk-body govuk-!-margin-bottom-0">
+                {page}
+              </strong>
+            ) : (
+              <a
+                key={page}
+                href="#"
+                className="govuk-link govuk-!-margin-bottom-0"
+                onClick={(e) => {
+                  e.preventDefault();
+                  onPageChange(page - 1);
+                }}
+              >
+                {page}
+              </a>
+            ),
+          )}
+          {currentPage < totalPages - 1 && (
+            <a
+              href="#"
+              className="govuk-link govuk-!-margin-bottom-0"
+              onClick={(e) => {
+                e.preventDefault();
+                onPageChange(currentPage + 1);
+              }}
+            >
+              Next »
+            </a>
+          )}
+        </nav>
+      )}
     </div>
   );
 };

--- a/frontend-two/components/shared/PagingPanel/index.tsx
+++ b/frontend-two/components/shared/PagingPanel/index.tsx
@@ -35,6 +35,7 @@ interface PagingPanelProps {
   pageSize: number;
   rowCount: number;
   noun?: string;
+  alignment?: "left" | "right";
   onPageChange: (page: number) => void;
 }
 
@@ -44,6 +45,7 @@ export const PagingPanel = ({
   pageSize,
   rowCount,
   noun = "row",
+  alignment = "right",
   onPageChange,
 }: PagingPanelProps) => {
   if (totalPages === 0 || rowCount === 0) return null;
@@ -60,8 +62,10 @@ export const PagingPanel = ({
   );
 
   return (
-    <div className="paging-panel flex justify-end">
-      <div className="w-full flex items-center justify-between">
+    <div
+      className={`paging-panel flex w-full ${alignment === "left" ? "justify-start" : "justify-end"}`}
+    >
+      <div className="inline-flex items-center gap-2">
         <span className="govuk-body paging-panel__count">
           Showing {firstRow} - {lastRow} of {rowCount} {pluralNoun}
         </span>

--- a/frontend-two/components/shared/Tooltip.tsx
+++ b/frontend-two/components/shared/Tooltip.tsx
@@ -5,6 +5,8 @@ interface TooltipProps {
   message?: string;
   underline?: boolean;
   selectable?: boolean;
+  onClick?: () => void;
+  className?: string;
   children: ReactNode;
 }
 
@@ -12,6 +14,8 @@ export const Tooltip = ({
   message,
   underline,
   selectable,
+  onClick,
+  className,
   children,
 }: TooltipProps) => {
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -38,9 +42,10 @@ export const Tooltip = ({
   return (
     <button
       ref={triggerRef}
-      className={`unbuttoned tooltip ${underline ? "tooltip--underline" : ""} ${selectable ? "tooltip--selectable" : ""}`}
+      className={`unbuttoned tooltip ${underline ? "tooltip--underline" : ""} ${selectable ? "tooltip--selectable" : ""} ${className ?? ""}`}
       title={message}
       type="button"
+      onClick={onClick}
     >
       {children}
     </button>

--- a/frontend-two/components/stop-analysis/StopAnalysisTable.tsx
+++ b/frontend-two/components/stop-analysis/StopAnalysisTable.tsx
@@ -92,14 +92,14 @@ const TABLE_COLUMN_OPTIONS: TableColumnDefinition[] = [
   {
     key: "averageScheduled",
     label: "Av. Scheduled Travel Time",
-    modalLabel: "Average Scheduled",
+    modalLabel: "Average scheduled",
   },
   {
     key: "averageActual",
     label: "Av. Actual Travel Time",
-    modalLabel: "Average Actual",
+    modalLabel: "Average actual",
   },
-  { key: "averageDelay", label: "Av. Delay", modalLabel: "Average Delay" },
+  { key: "averageDelay", label: "Av. Delay", modalLabel: "Average delay" },
   { key: "onTime", label: "On Time" },
   { key: "late", label: "Late" },
   { key: "early", label: "Early" },
@@ -477,7 +477,7 @@ export const StopAnalysisTable = ({
               ),
               stopName: (
                 <Tooltip
-                  message={`${row.stopName}\n${row.localityName}, ${row.adminAreaName}`}
+                  message={`${row.localityName}, ${row.adminAreaName}`}
                   className="stop-analysis-table__stop-link"
                   onClick={() => onStopNameClick(row)}
                 >

--- a/frontend-two/components/stop-analysis/StopAnalysisTable.tsx
+++ b/frontend-two/components/stop-analysis/StopAnalysisTable.tsx
@@ -81,7 +81,7 @@ const TABLE_COLUMN_OPTIONS: TableColumnDefinition[] = [
   { key: "direction", label: "Direction" },
   {
     key: "scheduledDepartures",
-    label: "Scheduled deparatures",
+    label: "Scheduled departures",
     modalLabel: "Scheduled departures",
   },
   {
@@ -107,7 +107,6 @@ const TABLE_COLUMN_OPTIONS: TableColumnDefinition[] = [
 
 interface StopAnalysisTableProps {
   data: StopPerformanceRow[];
-  loading: boolean;
   errored: boolean;
   directions: Direction[];
   onDirectionsChange: (directions: Direction[]) => void;
@@ -157,19 +156,8 @@ const getSortValue = (
   }
 };
 
-const formatSignedSeconds = (value: number | null | undefined): string => {
-  const formatted = formatSeconds(value);
-
-  if (formatted === "-" || formatted.startsWith("-")) {
-    return formatted;
-  }
-
-  return `+${formatted}`;
-};
-
 export const StopAnalysisTable = ({
   data,
-  loading,
   errored,
   directions,
   onDirectionsChange,
@@ -473,7 +461,7 @@ export const StopAnalysisTable = ({
           }
         >
           <SortedPaginatedTable
-            key={`${sortState.key}-${sortState.order}-${displayMode}-${visibleColumns.join(",")}`}
+            key={`${displayMode}-${visibleColumns.join(",")}`}
             columns={tableColumns}
             data={filteredData}
             getRowValue={(row, column) =>
@@ -504,11 +492,11 @@ export const StopAnalysisTable = ({
                   : String(row.actualDepartures),
               averageScheduled:
                 row.averageScheduled != null
-                  ? formatSignedSeconds(row.averageScheduled)
+                  ? formatSeconds(row.averageScheduled, true)
                   : "-",
               averageActual:
                 row.averageActual != null
-                  ? formatSignedSeconds(row.averageActual)
+                  ? formatSeconds(row.averageActual, true)
                   : "-",
               averageDelay:
                 row.averageDelay != null
@@ -536,16 +524,11 @@ export const StopAnalysisTable = ({
             }}
             initialSortKey={sortState.key}
             initialSortOrder={sortState.order}
-            emptyMessage={!loading ? "No stop data found" : undefined}
+            emptyMessage="No stop data found"
             paginationNoun="stop"
             paginationAlignment="left"
           />
         </div>
-        {loading ? (
-          <p className="govuk-body govuk-!-margin-top-4 govuk-!-text-align-centre">
-            Loading...
-          </p>
-        ) : null}
       </div>
     </div>
   );

--- a/frontend-two/components/stop-analysis/StopAnalysisTable.tsx
+++ b/frontend-two/components/stop-analysis/StopAnalysisTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { Direction, StopPerformanceRow } from "@/types/stop-analysis";
 import {
   DISPLAY_MODE_OPTIONS,
@@ -11,7 +11,12 @@ import {
 } from "@/hooks/useStopPerformanceTable";
 import { MultiselectCheckbox } from "@/components/shared/MultiselectCheckbox";
 import { Modal } from "@/components/shared/Modal";
-import { SortableTable, type SortOrder } from "../table/SortableTable";
+import { Tooltip } from "@/components/shared/Tooltip";
+import {
+  SortedPaginatedTable,
+  type SortedPaginatedTableColumn,
+} from "../table/SortedPaginatedTable";
+import { type SortOrder } from "../table/SortableTable";
 import { TimingIcon } from "./TimingIcon";
 
 type SortKey =
@@ -33,7 +38,6 @@ type SortableRow = {
   stopId: string;
   timingPoint: ReactNode;
   stopName: React.ReactNode;
-  source: StopPerformanceRow;
   direction: string;
   scheduledDepartures: number;
   actualDepartures: string;
@@ -62,6 +66,7 @@ type TableColumnKey =
 interface TableColumnDefinition {
   key: TableColumnKey;
   label: ReactNode;
+  modalLabel?: string;
   alwaysVisible?: boolean;
 }
 
@@ -70,17 +75,34 @@ const TABLE_COLUMN_OPTIONS: TableColumnDefinition[] = [
   {
     key: "timingPoint",
     label: <TimingIcon className="stop-analysis-table__timing-icon" />,
+    modalLabel: "Timing Point",
   },
-  { key: "stopName", label: "Name", alwaysVisible: true },
+  { key: "stopName", label: "Name" },
   { key: "direction", label: "Direction" },
-  { key: "scheduledDepartures", label: "Scheduled" },
-  { key: "actualDepartures", label: "Recorded" },
-  { key: "averageScheduled", label: "Av. Sched." },
-  { key: "averageActual", label: "Av. Actual" },
-  { key: "averageDelay", label: "Av. Delay" },
+  {
+    key: "scheduledDepartures",
+    label: "Scheduled deparatures",
+    modalLabel: "Scheduled departures",
+  },
+  {
+    key: "actualDepartures",
+    label: "Recorded departures",
+    modalLabel: "Recorded departures",
+  },
+  {
+    key: "averageScheduled",
+    label: "Av. Scheduled Travel Time",
+    modalLabel: "Average Scheduled",
+  },
+  {
+    key: "averageActual",
+    label: "Av. Actual Travel Time",
+    modalLabel: "Average Actual",
+  },
+  { key: "averageDelay", label: "Av. Delay", modalLabel: "Average Delay" },
   { key: "onTime", label: "On Time" },
-  { key: "early", label: "Early" },
   { key: "late", label: "Late" },
+  { key: "early", label: "Early" },
 ];
 
 interface StopAnalysisTableProps {
@@ -97,17 +119,6 @@ const formatDirection = (direction: string | null): string => {
   if (!direction) return "-";
 
   return direction.charAt(0).toUpperCase() + direction.slice(1);
-};
-
-const compareValue = (a: string | number, b: string | number): number => {
-  if (typeof a === "number" && typeof b === "number") {
-    return a - b;
-  }
-
-  return String(a).localeCompare(String(b), undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
 };
 
 const SORT_ASC: SortOrder = "asc";
@@ -146,6 +157,16 @@ const getSortValue = (
   }
 };
 
+const formatSignedSeconds = (value: number | null | undefined): string => {
+  const formatted = formatSeconds(value);
+
+  if (formatted === "-" || formatted.startsWith("-")) {
+    return formatted;
+  }
+
+  return `+${formatted}`;
+};
+
 export const StopAnalysisTable = ({
   data,
   loading,
@@ -156,7 +177,6 @@ export const StopAnalysisTable = ({
   showTotals = false,
 }: StopAnalysisTableProps) => {
   const [showDisplayOptions, setShowDisplayOptions] = useState(false);
-  const [currentPage, setCurrentPage] = useState(0);
   const [draftVisibleColumns, setDraftVisibleColumns] = useState<
     TableColumnKey[]
   >(TABLE_COLUMN_OPTIONS.map((column) => column.key));
@@ -195,53 +215,45 @@ export const StopAnalysisTable = ({
     showTotals,
   );
 
-  const sortedRows = useMemo(() => {
-    const rows = [...filteredData];
-    rows.sort((left, right) => {
-      const leftValue = getSortValue(left, sortState.key, displayMode);
-      const rightValue = getSortValue(right, sortState.key, displayMode);
-      const result = compareValue(leftValue, rightValue);
-      return sortState.order === SORT_ASC ? result : -result;
-    });
-    return rows;
-  }, [displayMode, filteredData, sortState]);
-
-  useEffect(() => {
-    setCurrentPage(0);
-  }, [sortedRows]);
-
   const visibleColumnSet = useMemo(
     () => new Set(visibleColumns),
     [visibleColumns],
   );
 
-  const tableColumns = useMemo(
+  const tableColumns = useMemo<SortedPaginatedTableColumn[]>(
     () =>
       TABLE_COLUMN_OPTIONS.filter((column) =>
         visibleColumnSet.has(column.key),
       ).map((column) => ({
         key: column.key,
         label: column.label,
+        ariaLabel:
+          column.modalLabel ??
+          (typeof column.label === "string" ? column.label : column.key),
+        alignment:
+          column.key === "direction" ||
+          column.key === "stopId" ||
+          column.key === "timingPoint" ||
+          column.key === "stopName"
+            ? "left"
+            : "right",
         sortable:
           column.key !== "stopId" &&
           column.key !== "stopName" &&
           column.key !== "timingPoint",
-        sortOrder: sortState.key === column.key ? sortState.order : undefined,
       })),
-    [sortState, visibleColumnSet],
+    [visibleColumnSet],
   );
-
-  const tableHead = tableColumns;
 
   const totalsRow = useMemo<SortableRow | null>(
     () =>
       totals
         ? {
             key: "__totals__",
+            rowClassName: "stop-analysis-table__summary-row",
             stopId: "-",
             timingPoint: "",
             stopName: "-",
-            source: null as unknown as StopPerformanceRow,
             direction: "-",
             ...totals,
           }
@@ -249,55 +261,8 @@ export const StopAnalysisTable = ({
     [totals],
   );
 
-  const PAGE_SIZE = 10;
-
-  const tableRows = useMemo<SortableRow[]>(
-    () =>
-      sortedRows
-        .slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE)
-        .map((row) => ({
-          key: `${row.stopId}-${row.direction}`,
-          stopId: row.stopId,
-          timingPoint: row.timingPoint ? (
-            <TimingIcon className="stop-analysis-table__timing-icon" />
-          ) : (
-            ""
-          ),
-          stopName: (
-            <button
-              type="button"
-              className="govuk-link stop-analysis-table__stop-link"
-              onClick={() => onStopNameClick(row)}
-              title={`${row.localityName}, ${row.adminAreaName}`}
-            >
-              {row.stopName}
-            </button>
-          ),
-          source: row,
-          direction: formatDirection(row.direction),
-          scheduledDepartures: row.scheduledDepartures,
-          actualDepartures: `${row.actualDepartures} (${formatPercent(row.completedRatio)})`,
-          averageScheduled:
-            row.averageScheduled != null
-              ? formatSeconds(row.averageScheduled)
-              : "-",
-          averageActual:
-            row.averageActual != null ? formatSeconds(row.averageActual) : "-",
-          averageDelay:
-            row.averageDelay != null ? formatSeconds(row.averageDelay) : "-",
-          onTime: formatMetricValue(row, "onTime", displayMode),
-          early: formatMetricValue(row, "early", displayMode),
-          late: formatMetricValue(row, "late", displayMode),
-        })),
-    [displayMode, onStopNameClick, sortedRows, currentPage],
-  );
-
-  const allTableRows = useMemo(
-    () => (totalsRow ? [totalsRow, ...tableRows] : tableRows),
-    [totalsRow, tableRows],
-  );
-
-  const handleSort = (key: string, order: SortOrder) => {
+  const handleSortChange = (key: string | null, order: SortOrder) => {
+    if (!key) return;
     setSortState({ key: key as SortKey, order });
   };
 
@@ -310,17 +275,13 @@ export const StopAnalysisTable = ({
     key: TableColumnKey,
     visible: boolean,
   ) => {
-    if (key === "stopName") {
-      return;
-    }
-
     setDraftVisibleColumns((current) => {
       if (visible) {
         return current.includes(key) ? current : [...current, key];
       }
 
       const next = current.filter((columnKey) => columnKey !== key);
-      return next.includes("stopName") ? next : ["stopName", ...next];
+      return next;
     });
   };
 
@@ -422,7 +383,7 @@ export const StopAnalysisTable = ({
                       className="govuk-label govuk-checkboxes__label"
                       htmlFor={`stop-analysis-column-${column.key}`}
                     >
-                      {column.label}
+                      {column.modalLabel ?? column.label}
                     </label>
                   </div>
                 );
@@ -460,7 +421,7 @@ export const StopAnalysisTable = ({
                       className="govuk-label govuk-checkboxes__label"
                       htmlFor={`stop-analysis-column-${column.key}`}
                     >
-                      {column.label}
+                      {column.modalLabel ?? column.label}
                     </label>
                   </div>
                 );
@@ -511,31 +472,78 @@ export const StopAnalysisTable = ({
             showTotals ? "stop-analysis-table__table--with-totals" : undefined
           }
         >
-          <SortableTable
-            head={tableHead as any}
-            rows={allTableRows as any[]}
-            onSort={handleSort}
-            pagination={
-              !loading && sortedRows.length > PAGE_SIZE
-                ? {
-                    currentPage,
-                    totalPages: Math.ceil(sortedRows.length / PAGE_SIZE),
-                    pageSize: PAGE_SIZE,
-                    rowCount: sortedRows.length,
-                    noun: "stop",
-                    onPageChange: setCurrentPage,
-                  }
-                : undefined
+          <SortedPaginatedTable
+            key={`${sortState.key}-${sortState.order}-${displayMode}-${visibleColumns.join(",")}`}
+            columns={tableColumns}
+            data={filteredData}
+            getRowValue={(row, column) =>
+              getSortValue(row, column as SortKey, displayMode)
             }
+            renderRow={(row) => ({
+              key: `${row.stopId}-${row.direction}`,
+              stopId: row.stopId,
+              timingPoint: row.timingPoint ? (
+                <TimingIcon className="stop-analysis-table__timing-icon" />
+              ) : (
+                ""
+              ),
+              stopName: (
+                <Tooltip
+                  message={`${row.stopName}\n${row.localityName}, ${row.adminAreaName}`}
+                  className="stop-analysis-table__stop-link"
+                  onClick={() => onStopNameClick(row)}
+                >
+                  {row.stopName}
+                </Tooltip>
+              ),
+              direction: formatDirection(row.direction),
+              scheduledDepartures: row.scheduledDepartures,
+              actualDepartures:
+                displayMode === "percentage"
+                  ? formatPercent(row.completedRatio)
+                  : String(row.actualDepartures),
+              averageScheduled:
+                row.averageScheduled != null
+                  ? formatSignedSeconds(row.averageScheduled)
+                  : "-",
+              averageActual:
+                row.averageActual != null
+                  ? formatSignedSeconds(row.averageActual)
+                  : "-",
+              averageDelay:
+                row.averageDelay != null
+                  ? formatSeconds(row.averageDelay)
+                  : "-",
+              onTime: formatMetricValue(row, "onTime", displayMode),
+              early: formatMetricValue(row, "early", displayMode),
+              late: formatMetricValue(row, "late", displayMode),
+            })}
+            pinnedRows={totalsRow ? [totalsRow] : undefined}
+            onSortChange={handleSortChange}
+            colWidths={{
+              stopId: "8rem",
+              timingPoint: "2rem",
+              stopName: "12rem",
+              direction: "5.5rem",
+              scheduledDepartures: "5rem",
+              actualDepartures: "6rem",
+              averageScheduled: "5rem",
+              averageActual: "5rem",
+              averageDelay: "5rem",
+              onTime: "4.5rem",
+              early: "4.5rem",
+              late: "4.5rem",
+            }}
+            initialSortKey={sortState.key}
+            initialSortOrder={sortState.order}
+            emptyMessage={!loading ? "No stop data found" : undefined}
+            paginationNoun="stop"
+            paginationAlignment="left"
           />
         </div>
         {loading ? (
           <p className="govuk-body govuk-!-margin-top-4 govuk-!-text-align-centre">
             Loading...
-          </p>
-        ) : allTableRows.length === 0 ? (
-          <p className="govuk-body govuk-!-margin-top-4 govuk-!-text-align-centre">
-            No stop data found
           </p>
         ) : null}
       </div>

--- a/frontend-two/components/table/SortableTable.tsx
+++ b/frontend-two/components/table/SortableTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode } from "react";
 import { PagingPanel } from "@/components/shared/PagingPanel";
 
 export type SortOrder = "asc" | "desc" | "none";
@@ -62,19 +62,6 @@ const unsortedIcon = (
 const getAlignmentClassName = (alignment?: "left" | "right" | "center") =>
   alignment ? `sortable-table__align--${alignment}` : "";
 
-function getNextOrder(
-  prevState: { key: string; order: SortOrder } | null,
-  key: string,
-): SortOrder {
-  if (!prevState || prevState.key !== key || prevState.order === "none") {
-    return "asc";
-  }
-  if (prevState.order === "asc") {
-    return "desc";
-  }
-  return "none";
-}
-
 export const SortableTable = ({
   head,
   rows,
@@ -84,49 +71,23 @@ export const SortableTable = ({
   paginationAlignment = "right",
   colWidths,
 }: SortableTableProps): React.JSX.Element => {
-  const [sortState, setSortState] = useState<{
-    key: string;
-    order: SortOrder;
-  } | null>(null);
-
-  useEffect(() => {
-    const initialSortColumn = head.find(
-      (column) =>
-        column.sortable && column.sortOrder && column.sortOrder !== "none",
-    );
-    const nextSortState = initialSortColumn
-      ? {
-          key: initialSortColumn.key,
-          order: initialSortColumn.sortOrder!,
-        }
-      : null;
-
-    setSortState((currentSortState) => {
-      if (
-        currentSortState?.key === nextSortState?.key &&
-        currentSortState?.order === nextSortState?.order
-      ) {
-        return currentSortState;
-      }
-
-      return nextSortState;
-    });
-  }, [head]);
-
   const handleSort = (key: string) => {
-    const newOrder = getNextOrder(sortState, key);
-    setSortState(newOrder === "none" ? null : { key, order: newOrder });
+    const current = head.find((c) => c.key === key)?.sortOrder ?? "none";
+    const newOrder: SortOrder =
+      current === "none" ? "asc" : current === "asc" ? "desc" : "none";
     onSort(key, newOrder);
   };
 
-  const getSortIcon = (key: string): React.ReactNode => {
-    if (!sortState || sortState.key !== key) return unsortedIcon;
-    return sortState.order === "asc" ? ascIcon : descIcon;
+  const getSortIcon = (cell: SortableTableHeadCell): React.ReactNode => {
+    if (!cell.sortOrder || cell.sortOrder === "none") return unsortedIcon;
+    return cell.sortOrder === "asc" ? ascIcon : descIcon;
   };
 
-  const getAriaSort = (key: string): "none" | "ascending" | "descending" => {
-    if (!sortState || sortState.key !== key) return "none";
-    return sortState.order === "asc" ? "ascending" : "descending";
+  const getAriaSort = (
+    cell: SortableTableHeadCell,
+  ): "none" | "ascending" | "descending" => {
+    if (!cell.sortOrder || cell.sortOrder === "none") return "none";
+    return cell.sortOrder === "asc" ? "ascending" : "descending";
   };
 
   return (
@@ -154,18 +115,18 @@ export const SortableTable = ({
               <th
                 key={item.key}
                 className={`govuk-table__header ${getAlignmentClassName(item.alignment)} ${item.headerClassName ?? ""}`.trim()}
-                {...(item?.sortable && { "aria-sort": getAriaSort(item.key) })}
+                {...(item?.sortable && { "aria-sort": getAriaSort(item) })}
               >
                 {item.sortable ? (
                   <button
                     type="button"
                     className={`sortable-header ${getAlignmentClassName(item.alignment)} ${item.headerClassName ?? ""}`.trim()}
                     onClick={() => handleSort(item.key)}
-                    aria-label={`Sort by ${item.ariaLabel ?? (typeof item.label === "string" ? item.label : item.key)} ${getAriaSort(item.key)}`}
+                    aria-label={`Sort by ${item.ariaLabel ?? (typeof item.label === "string" ? item.label : item.key)} ${getAriaSort(item)}`}
                     data-testid={`sortable-header-${item.key}`}
                   >
                     <span className="sortable-header__label">{item.label}</span>
-                    {getSortIcon(item.key)}
+                    {getSortIcon(item)}
                   </button>
                 ) : (
                   <span className="sortable-header__label">{item.label}</span>
@@ -184,7 +145,7 @@ export const SortableTable = ({
                 <td
                   key={column.key}
                   className={`govuk-table__cell ${getAlignmentClassName(column.alignment)} ${column.cellClassName ?? ""}`.trim()}
-                  data-label={column.label}
+                  data-label={typeof column.label === "string" ? column.label : (column.ariaLabel ?? column.key)}
                 >
                   {row[column.key]}
                 </td>

--- a/frontend-two/components/table/SortableTable.tsx
+++ b/frontend-two/components/table/SortableTable.tsx
@@ -1,27 +1,23 @@
-import dynamic from "next/dynamic";
-import { ReactNode } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { PagingPanel } from "@/components/shared/PagingPanel";
-
-const KainosSortableTable = dynamic(
-  () =>
-    import("kainossoftwareltd-govuk-react-kainos").then(
-      (mod) => mod.SortableTable,
-    ),
-  { ssr: false },
-);
 
 export type SortOrder = "asc" | "desc" | "none";
 
 export interface SortableTableHeadCell {
   key: string;
-  label: string;
+  label: ReactNode;
   sortable: boolean;
   sortOrder?: SortOrder;
+  ariaLabel?: string;
+  alignment?: "left" | "right" | "center";
+  cellClassName?: string;
+  headerClassName?: string;
 }
 
 export interface SortableTableRow {
   key: string;
   [key: string]: ReactNode;
+  rowClassName?: string;
 }
 
 export interface SortableTablePagination {
@@ -30,6 +26,7 @@ export interface SortableTablePagination {
   pageSize: number;
   rowCount: number;
   noun?: string;
+  alignment?: "left" | "right";
   onPageChange: (page: number) => void;
 }
 
@@ -39,6 +36,43 @@ export interface SortableTableProps {
   onSort: (column: string, order: SortOrder) => void;
   title?: ReactNode;
   pagination?: SortableTablePagination;
+  paginationAlignment?: "left" | "right";
+  colWidths?: Partial<Record<string, string>>;
+}
+
+const ascIcon = (
+  <span
+    aria-hidden="true"
+    className="sortable-table-sort-icon sortable-table-sort-icon--asc"
+  />
+);
+const descIcon = (
+  <span
+    aria-hidden="true"
+    className="sortable-table-sort-icon sortable-table-sort-icon--desc"
+  />
+);
+const unsortedIcon = (
+  <span
+    aria-hidden="true"
+    className="sortable-table-sort-icon sortable-table-sort-icon--none"
+  />
+);
+
+const getAlignmentClassName = (alignment?: "left" | "right" | "center") =>
+  alignment ? `sortable-table__align--${alignment}` : "";
+
+function getNextOrder(
+  prevState: { key: string; order: SortOrder } | null,
+  key: string,
+): SortOrder {
+  if (!prevState || prevState.key !== key || prevState.order === "none") {
+    return "asc";
+  }
+  if (prevState.order === "asc") {
+    return "desc";
+  }
+  return "none";
 }
 
 export const SortableTable = ({
@@ -47,27 +81,131 @@ export const SortableTable = ({
   onSort,
   title,
   pagination,
-}: SortableTableProps) => (
-  <>
-    {title ? <h2 className="govuk-heading-m">{title}</h2> : null}
-    <KainosSortableTable
-      head={head as any}
-      rows={rows as any[]}
-      onSort={onSort}
-    />
-    {pagination ? (
-      <div className="flex justify-end">
-        <div className="w-1/2">
+  paginationAlignment = "right",
+  colWidths,
+}: SortableTableProps): React.JSX.Element => {
+  const [sortState, setSortState] = useState<{
+    key: string;
+    order: SortOrder;
+  } | null>(null);
+
+  useEffect(() => {
+    const initialSortColumn = head.find(
+      (column) =>
+        column.sortable && column.sortOrder && column.sortOrder !== "none",
+    );
+    const nextSortState = initialSortColumn
+      ? {
+          key: initialSortColumn.key,
+          order: initialSortColumn.sortOrder!,
+        }
+      : null;
+
+    setSortState((currentSortState) => {
+      if (
+        currentSortState?.key === nextSortState?.key &&
+        currentSortState?.order === nextSortState?.order
+      ) {
+        return currentSortState;
+      }
+
+      return nextSortState;
+    });
+  }, [head]);
+
+  const handleSort = (key: string) => {
+    const newOrder = getNextOrder(sortState, key);
+    setSortState(newOrder === "none" ? null : { key, order: newOrder });
+    onSort(key, newOrder);
+  };
+
+  const getSortIcon = (key: string): React.ReactNode => {
+    if (!sortState || sortState.key !== key) return unsortedIcon;
+    return sortState.order === "asc" ? ascIcon : descIcon;
+  };
+
+  const getAriaSort = (key: string): "none" | "ascending" | "descending" => {
+    if (!sortState || sortState.key !== key) return "none";
+    return sortState.order === "asc" ? "ascending" : "descending";
+  };
+
+  return (
+    <>
+      {title ? <h2 className="govuk-heading-m">{title}</h2> : null}
+      <table
+        className="govuk-table sortable-table"
+        style={{ tableLayout: colWidths ? "fixed" : undefined, width: "100%" }}
+      >
+        {colWidths && (
+          <colgroup>
+            {head.map((col) => (
+              <col
+                key={col.key}
+                style={
+                  colWidths[col.key] ? { width: colWidths[col.key] } : undefined
+                }
+              />
+            ))}
+          </colgroup>
+        )}
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            {head.map((item) => (
+              <th
+                key={item.key}
+                className={`govuk-table__header ${getAlignmentClassName(item.alignment)} ${item.headerClassName ?? ""}`.trim()}
+                {...(item?.sortable && { "aria-sort": getAriaSort(item.key) })}
+              >
+                {item.sortable ? (
+                  <button
+                    type="button"
+                    className={`sortable-header ${getAlignmentClassName(item.alignment)} ${item.headerClassName ?? ""}`.trim()}
+                    onClick={() => handleSort(item.key)}
+                    aria-label={`Sort by ${item.ariaLabel ?? (typeof item.label === "string" ? item.label : item.key)} ${getAriaSort(item.key)}`}
+                    data-testid={`sortable-header-${item.key}`}
+                  >
+                    <span className="sortable-header__label">{item.label}</span>
+                    {getSortIcon(item.key)}
+                  </button>
+                ) : (
+                  <span className="sortable-header__label">{item.label}</span>
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          {rows.map((row) => (
+            <tr
+              key={row.key}
+              className={`govuk-table__row ${row.rowClassName ?? ""}`.trim()}
+            >
+              {head.map((column) => (
+                <td
+                  key={column.key}
+                  className={`govuk-table__cell ${getAlignmentClassName(column.alignment)} ${column.cellClassName ?? ""}`.trim()}
+                  data-label={column.label}
+                >
+                  {row[column.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {pagination ? (
+        <div>
           <PagingPanel
             currentPage={pagination.currentPage}
             totalPages={pagination.totalPages}
             pageSize={pagination.pageSize}
             rowCount={pagination.rowCount}
             noun={pagination.noun ?? "row"}
+            alignment={pagination.alignment ?? paginationAlignment}
             onPageChange={pagination.onPageChange}
           />
         </div>
-      </div>
-    ) : null}
-  </>
-);
+      ) : null}
+    </>
+  );
+};

--- a/frontend-two/components/table/SortableTable.tsx
+++ b/frontend-two/components/table/SortableTable.tsx
@@ -145,7 +145,11 @@ export const SortableTable = ({
                 <td
                   key={column.key}
                   className={`govuk-table__cell ${getAlignmentClassName(column.alignment)} ${column.cellClassName ?? ""}`.trim()}
-                  data-label={typeof column.label === "string" ? column.label : (column.ariaLabel ?? column.key)}
+                  data-label={
+                    typeof column.label === "string"
+                      ? column.label
+                      : column.ariaLabel ?? column.key
+                  }
                 >
                   {row[column.key]}
                 </td>

--- a/frontend-two/components/table/SortedPaginatedTable.tsx
+++ b/frontend-two/components/table/SortedPaginatedTable.tsx
@@ -10,8 +10,12 @@ const DEFAULT_PAGE_SIZE = 10;
 
 export interface SortedPaginatedTableColumn {
   key: string;
-  label: string;
+  label: ReactNode;
   sortable?: boolean;
+  ariaLabel?: string;
+  alignment?: "left" | "right" | "center";
+  cellClassName?: string;
+  headerClassName?: string;
 }
 
 export interface SortedPaginatedTableProps<T> {
@@ -25,7 +29,11 @@ export interface SortedPaginatedTableProps<T> {
   emptyMessage?: string;
   initialSortKey?: string | null;
   initialSortOrder?: SortOrder;
+  paginationResetKey?: string | number | boolean;
   paginationNoun?: string;
+  paginationAlignment?: "left" | "right";
+  onSortChange?: (key: string | null, order: SortOrder) => void;
+  colWidths?: Partial<Record<string, string>>;
 }
 
 export const SortedPaginatedTable = <T,>({
@@ -39,7 +47,11 @@ export const SortedPaginatedTable = <T,>({
   emptyMessage,
   initialSortKey = null,
   initialSortOrder = "none",
+  paginationResetKey,
   paginationNoun = "row",
+  paginationAlignment = "right",
+  onSortChange,
+  colWidths,
 }: SortedPaginatedTableProps<T>) => {
   const [currentPage, setCurrentPage] = useState(0);
   const [sortKey, setSortKey] = useState<string | null>(initialSortKey);
@@ -47,7 +59,7 @@ export const SortedPaginatedTable = <T,>({
 
   useEffect(() => {
     setCurrentPage(0);
-  }, [data]);
+  }, [data, paginationResetKey]);
 
   const sortedData = useMemo(() => {
     if (!sortKey || sortOrder === "none") return data;
@@ -73,6 +85,7 @@ export const SortedPaginatedTable = <T,>({
     setSortKey(column);
     setSortOrder(order);
     setCurrentPage(0);
+    onSortChange?.(column, order);
   };
 
   const totalPages = Math.ceil(sortedData.length / pageSize);
@@ -86,6 +99,10 @@ export const SortedPaginatedTable = <T,>({
     label: col.label,
     sortable: col.sortable ?? false,
     sortOrder: sortKey === col.key ? sortOrder : undefined,
+    ariaLabel: col.ariaLabel,
+    alignment: col.alignment,
+    cellClassName: col.cellClassName,
+    headerClassName: col.headerClassName,
   }));
 
   const rows: SortableTableRow[] = [
@@ -102,6 +119,7 @@ export const SortedPaginatedTable = <T,>({
           rowCount: sortedData.length,
           onPageChange: setCurrentPage,
           noun: paginationNoun ?? "row",
+          alignment: paginationAlignment,
         }
       : undefined;
 
@@ -113,6 +131,8 @@ export const SortedPaginatedTable = <T,>({
         onSort={handleSort}
         title={title}
         pagination={pagination}
+        paginationAlignment={paginationAlignment}
+        colWidths={colWidths}
       />
       {emptyMessage && data.length === 0 && (
         <div className="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-4 text-center">

--- a/frontend-two/hooks/useStopPerformanceTable.ts
+++ b/frontend-two/hooks/useStopPerformanceTable.ts
@@ -14,11 +14,14 @@ export const formatPercent = (value: number | undefined | null): string => {
   return `${(value * 100).toFixed(1)}%`;
 };
 
-export const formatSeconds = (value: number | undefined | null): string => {
+export const formatSeconds = (
+  value: number | undefined | null,
+  signed = false,
+): string => {
   if (value == null || isNaN(value)) return "-";
   const mins = Math.floor(Math.abs(value) / 60);
   const secs = Math.round(Math.abs(value) % 60);
-  const sign = value < 0 ? "-" : "";
+  const sign = signed ? (value < 0 ? "-" : "+") : value < 0 ? "-" : "";
   return `${sign}${mins}:${secs.toString().padStart(2, "0")}`;
 };
 
@@ -170,12 +173,12 @@ export function useStopPerformanceTable(
     return {
       scheduledDepartures: totalScheduled,
       actualDepartures:
-        completedRatio != null
-          ? `${totalActual} (${formatPercent(completedRatio)})`
+        displayMode === "percentage"
+          ? formatPercent(completedRatio)
           : String(totalActual),
       averageScheduled:
-        avgScheduled != null ? formatSeconds(avgScheduled) : "-",
-      averageActual: avgActual != null ? formatSeconds(avgActual) : "-",
+        avgScheduled != null ? formatSeconds(avgScheduled, true) : "-",
+      averageActual: avgActual != null ? formatSeconds(avgActual, true) : "-",
       averageDelay: avgDelay != null ? formatSeconds(avgDelay) : "-",
       onTime,
       early,

--- a/frontend-two/pages/stop-analysis.tsx
+++ b/frontend-two/pages/stop-analysis.tsx
@@ -832,7 +832,6 @@ const StopAnalysisPage = () => {
         ) : (
           <StopAnalysisTable
             data={tableRows}
-            loading={stopsLoading}
             errored={!!stopsError}
             directions={directions}
             showTotals

--- a/frontend-two/pages/stop-analysis.tsx
+++ b/frontend-two/pages/stop-analysis.tsx
@@ -119,6 +119,21 @@ const refineValuesToStopFiltersQuery = (
   endTime: values.endTime === "23:59" ? undefined : values.endTime,
 });
 
+const LoadingDots = () => (
+  <div
+    className="stop-analysis-page__loading-state govuk-!-margin-top-4"
+    role="status"
+    aria-live="polite"
+  >
+    <span className="ranking-table__loading-dots" aria-hidden="true">
+      <span className="ranking-table__loading-dot" />
+      <span className="ranking-table__loading-dot" />
+      <span className="ranking-table__loading-dot" />
+    </span>
+    <span className="govuk-body-s govuk-!-margin-bottom-0">Loading...</span>
+  </div>
+);
+
 function parseArrayParam(param: string | string[] | undefined): string[] {
   if (!param) return [];
   return Array.isArray(param) ? param : [param];
@@ -812,19 +827,23 @@ const StopAnalysisPage = () => {
             onAdminAreaClick={handleAdminAreaClick}
           />
         )}
-        <StopAnalysisTable
-          data={tableRows}
-          loading={stopsLoading}
-          errored={!!stopsError}
-          directions={directions}
-          showTotals
-          onDirectionsChange={(dirs) =>
-            updateQuery({
-              direction: dirs.length === 0 ? EMPTY_DIRECTION_SELECTION : dirs,
-            })
-          }
-          onStopNameClick={handleStopClick}
-        />
+        {stopsLoading ? (
+          <LoadingDots />
+        ) : (
+          <StopAnalysisTable
+            data={tableRows}
+            loading={stopsLoading}
+            errored={!!stopsError}
+            directions={directions}
+            showTotals
+            onDirectionsChange={(dirs) =>
+              updateQuery({
+                direction: dirs.length === 0 ? EMPTY_DIRECTION_SELECTION : dirs,
+              })
+            }
+            onStopNameClick={handleStopClick}
+          />
+        )}
       </div>
     </BaseLayout>
   );

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -4220,6 +4220,12 @@ body.modal-open {
     font-weight: $govuk-font-weight-bold;
   }
 
+  .govuk-table__cell,
+  .govuk-table__header {
+    @include govuk-font(16);
+    vertical-align: middle;
+  }
+
   &__stop-link {
     display: inline-block;
     max-width: 100%;

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -3480,10 +3480,6 @@ body.helpdesk-open {
     position: relative;
   }
 
-  &__location-input {
-    width: 100%;
-  }
-
   &__location-results {
     position: absolute;
     z-index: 100;
@@ -3502,7 +3498,8 @@ body.helpdesk-open {
   }
 
   &__location-input {
-    padding-right: govuk-spacing(6);
+    width: 100%;
+    padding-right: govuk-spacing(9);
   }
 
   &__location-chevron {
@@ -3552,6 +3549,64 @@ body.helpdesk-open {
     margin-left: govuk-spacing(1);
     @include govuk-font(14);
     color: $govuk-secondary-text-colour;
+  }
+
+  &__location-selected {
+    display: flex;
+    align-items: center;
+    cursor: text;
+    user-select: none;
+    overflow: hidden;
+    padding-right: govuk-spacing(9);
+    position: relative;
+
+    &:focus-within {
+      outline: 3px solid $govuk-focus-colour;
+      outline-offset: 0;
+    }
+
+    &:hover {
+      border-color: govuk-colour("black");
+    }
+  }
+
+  &__location-overlay-input {
+    position: absolute;
+    inset: 0;
+    border: 0;
+    background: transparent;
+    color: transparent;
+    caret-color: $govuk-text-colour;
+    outline: 0;
+    padding: inherit;
+    font-size: inherit;
+    cursor: text;
+  }
+
+  &__location-selected-text {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__location-clear {
+    position: absolute;
+    top: 50%;
+    right: govuk-spacing(6);
+    transform: translateY(-50%);
+    padding: 0 govuk-spacing(1);
+    border: 0;
+    background: none;
+    cursor: pointer;
+    @include govuk-font(16);
+    font-weight: $govuk-font-weight-bold;
+    color: $govuk-secondary-text-colour;
+    line-height: 1;
+
+    &:hover {
+      color: $govuk-text-colour;
+    }
   }
 
   &__refine-button {

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -1250,9 +1250,10 @@ $day-width: 46px;
 }
 
 // SortableTable styling
-.kns-table .sortable-header {
+.sortable-table .sortable-header {
   display: flex;
   font-size: 17px;
+  font-weight: $govuk-font-weight-bold;
   text-decoration: none;
   cursor: pointer;
   color: $govuk-link-colour;
@@ -1260,16 +1261,67 @@ $day-width: 46px;
   align-items: center;
 }
 
-.kns-table .sortable-header:hover {
+.sortable-table .sortable-header:hover {
   color: $govuk-link-hover-colour;
 }
 
-.kns-table .sortable-header svg {
+.sortable-table__align--right {
+  justify-content: flex-end;
+  width: 100%;
+  text-align: right;
+}
+
+.sortable-table__align--center {
+  justify-content: center;
+  width: 100%;
+  text-align: center;
+}
+
+.sortable-table .sortable-header.sortable-table__align--left {
+  justify-content: flex-start;
+  width: 100%;
+  text-align: left;
+}
+
+.sortable-table-sort-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 4px;
   flex-shrink: 0;
+  color: $govuk-link-colour;
+  line-height: 1;
+  vertical-align: middle;
+  // height is set by --none's two stacked 8px chars (~16px)
+  min-height: 16px;
+
+  &--asc::before {
+    content: "\25b2";
+    font-size: 14px;
+  }
+
+  &--desc::before {
+    content: "\25bc";
+    font-size: 14px;
+  }
+
+  &--none {
+    color: govuk-colour("mid-grey");
+    font-size: 8px;
+
+    &::before {
+      content: "\25b2\a\25bc";
+      white-space: pre;
+      display: block;
+      text-align: center;
+      line-height: 1;
+    }
+  }
 }
 
 .govuk-table__header {
   font-size: 17px;
+  font-weight: $govuk-font-weight-bold;
 }
 
 // Corridor stop list styling for create/edit corridor flow
@@ -3326,6 +3378,15 @@ body.helpdesk-open {
     gap: govuk-spacing(4);
     padding: govuk-spacing(2) 0;
   }
+
+  &__loading-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: govuk-spacing(2);
+    min-height: 108px;
+  }
 }
 
 .stop-analysis-filters {
@@ -3484,6 +3545,13 @@ body.helpdesk-open {
     &:hover {
       background: govuk-colour("light-grey");
     }
+  }
+
+  &__location-option-context {
+    display: inline;
+    margin-left: govuk-spacing(1);
+    @include govuk-font(14);
+    color: $govuk-secondary-text-colour;
   }
 
   &__refine-button {
@@ -4148,17 +4216,21 @@ body.modal-open {
     }
   }
 
-  &__stop-link {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    text-decoration: underline;
-    color: $govuk-link-colour;
+  &__summary-row > * {
+    font-weight: $govuk-font-weight-bold;
+  }
 
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
+  &__stop-link {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+  }
+
+  &__cell--numeric {
+    text-align: right;
   }
 
   &__timing-icon {
@@ -4169,5 +4241,22 @@ body.modal-open {
     height: 1.25rem;
     color: $govuk-text-colour;
     vertical-align: middle;
+  }
+
+  .sortable-header__label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    white-space: normal;
+    text-overflow: ellipsis;
+  }
+
+  .sortable-header {
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .sortable-header.sortable-table__align--left {
+    gap: govuk-spacing(1);
   }
 }

--- a/frontend-two/types/mapbox.ts
+++ b/frontend-two/types/mapbox.ts
@@ -1,0 +1,45 @@
+export const GEOCODING_TYPES = [
+  "poi",
+  "address",
+  "neighborhood",
+  "locality",
+  "place",
+  "district",
+  "postcode",
+  "region",
+  "country",
+] as const;
+
+export type GeocodingType = (typeof GEOCODING_TYPES)[number];
+
+export type GeocodingContext = { id: string; text: string };
+
+export interface GeocodingFeature {
+  id: string;
+  text: string;
+  context?: GeocodingContext[];
+  center?: [number, number];
+  bbox?: [number, number, number, number];
+}
+
+export const getContextText = (
+  context: GeocodingContext[],
+  types: GeocodingType[],
+): string | undefined =>
+  context.find((ctx) => types.includes(ctx.id.split(".")[0] as GeocodingType))
+    ?.text;
+
+export const buildLocationContext = (
+  context: GeocodingContext[],
+): string | undefined => {
+  const parts = [
+    getContextText(context, ["locality"]),
+    getContextText(context, ["place", "district"]),
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : undefined;
+};
+
+export const buildLocationSearchTypes = (
+  excludeTypes: GeocodingType[],
+): string =>
+  GEOCODING_TYPES.filter((type) => !excludeTypes.includes(type)).join(",");


### PR DESCRIPTION
* Previous component didn't have a state for default sorting (now implemented domestically and updated usage)
* Modal options were sharing wrapping with table
* Adds missing location filters for POI etc.
* Tooltips in the table
* Name no longer blue on stop analysis

https://busopendataservice.atlassian.net/browse/DBODS-2018
https://busopendataservice.atlassian.net/browse/DBODS-2019