### PR TITLE
DBODS-2236: On time page defects

### DIFF
--- a/frontend-two/components/feed-monitoring/FeedTable.tsx
+++ b/frontend-two/components/feed-monitoring/FeedTable.tsx
@@ -97,6 +97,7 @@ export const FeedTable = ({
       name: (
         <Link
           className="govuk-link font-bold"
+          style={{ textDecoration: "none" }}
           href={`/feed-monitoring/${op.nocCode}`}
         >
           {op.name}

--- a/frontend-two/components/on-time/OnTimeFilterPanel.tsx
+++ b/frontend-two/components/on-time/OnTimeFilterPanel.tsx
@@ -109,6 +109,11 @@ export const OnTimeFilterPanel = ({
   refineResultsFilters,
   onRefineResultsFilterChange,
 }: OnTimeFilterPanelProps) => {
+  const datePresetItems =
+    selectedDatePreset === "Custom" && !datePresetOptions.includes("Custom")
+      ? [...datePresetOptions, "Custom"]
+      : datePresetOptions;
+
   return (
     <>
       <div className="controls-container">
@@ -121,7 +126,7 @@ export const OnTimeFilterPanel = ({
           <Select
             name="date-preset"
             label=""
-            items={datePresetOptions.map((preset) => ({
+            items={datePresetItems.map((preset) => ({
               value: preset,
               text: preset,
               selected: selectedDatePreset === preset,

--- a/frontend-two/components/on-time/OnTimeOperatorTable.tsx
+++ b/frontend-two/components/on-time/OnTimeOperatorTable.tsx
@@ -32,7 +32,12 @@ const columns = [
   { key: "onTimeRatio", label: "On-time", sortable: true },
   { key: "lateRatio", label: "Late", sortable: true },
   { key: "earlyRatio", label: "Early", sortable: true },
-  { key: "sparkline", label: "", sortable: false },
+  {
+    key: "sparkline",
+    label: "",
+    sortable: false,
+    cellClassName: "on-time-operator-table__sparkline-cell",
+  },
 ];
 
 function getSparklineKey(row: OperatorPerformance): string | null {

--- a/frontend-two/components/on-time/OnTimeOperatorTable.tsx
+++ b/frontend-two/components/on-time/OnTimeOperatorTable.tsx
@@ -96,6 +96,7 @@ function renderRow(
     name: row.nocCode ? (
       <Link
         href={`/on-time/${encodeURIComponent(row.nocCode)}`}
+        style={{ textDecoration: "none" }}
         className="govuk-link govuk-!-font-weight-bold"
       >
         {row.name}

--- a/frontend-two/components/on-time/OnTimeOperatorTable.tsx
+++ b/frontend-two/components/on-time/OnTimeOperatorTable.tsx
@@ -84,6 +84,7 @@ function getRowValue(
 function renderRow(
   row: OperatorPerformance,
   sparklineByOperatorId: Record<string, TimeSeriesData[]>,
+  sparklineParams: PerformanceParams | null | undefined,
 ): SortableTableRow {
   const sparklineKey = getSparklineKey(row);
   const sparklineData = sparklineKey
@@ -110,7 +111,11 @@ function renderRow(
     earlyRatio: formatPercentage(row.earlyRatio),
     sparkline:
       sparklineKey && sparklineData.length > 0 ? (
-        <OperatorSparkline data={sparklineData} />
+        <OperatorSparkline
+          data={sparklineData}
+          fromTimestamp={sparklineParams?.fromTimestamp}
+          toTimestamp={sparklineParams?.toTimestamp}
+        />
       ) : (
         "-"
       ),
@@ -255,7 +260,7 @@ export const OnTimeOperatorTable = ({
   );
 
   const renderOperatorRow = (row: OperatorPerformance) =>
-    renderRow(row, sparklineByOperatorId);
+    renderRow(row, sparklineByOperatorId, granularSparklineParams);
 
   return (
     <SortedPaginatedTable

--- a/frontend-two/components/on-time/OnTimeOperatorTable.tsx
+++ b/frontend-two/components/on-time/OnTimeOperatorTable.tsx
@@ -265,12 +265,12 @@ export const OnTimeOperatorTable = ({
       renderRow={renderOperatorRow}
       colWidths={{
         nocCode: "10%",
-        name: "30%",
+        name: "20%",
         averageDelay: "12%",
         onTimeRatio: "12%",
         lateRatio: "12%",
         earlyRatio: "12%",
-        sparkline: "12%",
+        sparkline: "22%",
       }}
       initialSortKey="name"
       initialSortOrder="asc"

--- a/frontend-two/components/on-time/OnTimeServicesTable.tsx
+++ b/frontend-two/components/on-time/OnTimeServicesTable.tsx
@@ -121,6 +121,7 @@ function createRenderRow(nocCode: string, displayMode: OnTimeDisplayMode) {
       service: (
         <Link
           href={`/on-time/${encodeURIComponent(nocCode)}/${encodeURIComponent(row.lineId ?? "")}`}
+          style={{ textDecoration: "none" }}
           className="govuk-link"
         >
           {row.lineInfo?.serviceNumber}: {row.lineInfo?.serviceName}

--- a/frontend-two/components/on-time/OnTimeStopsTable.tsx
+++ b/frontend-two/components/on-time/OnTimeStopsTable.tsx
@@ -297,6 +297,7 @@ export const OnTimeStopsTable = ({
           paginationNoun="stop"
           emptyMessage="No stop performance data available"
           onDisplayedDataChange={setDisplayedRows}
+          enablePagination={false}
         />
       </div>
       <div className="govuk-!-margin-top-4">

--- a/frontend-two/components/on-time/OperatorSparkline.tsx
+++ b/frontend-two/components/on-time/OperatorSparkline.tsx
@@ -42,7 +42,7 @@ export const OperatorSparkline = ({
     chart.height = am4core.percent(100);
     chart.padding(2, 2, 2, 2);
     chart.margin(0, 0, 0, 0);
-    chart.maskBullets = false;
+    chart.maskBullets = true;
     chart.dateFormatter.inputDateFormat = "yyyy-MM-ddTHH:mm:ss";
 
     const dateAxis = chart.xAxes.push(new am4charts.DateAxis());
@@ -60,7 +60,6 @@ export const OperatorSparkline = ({
     series.stroke = am4core.color("#6A3D9A");
     series.strokeWidth = 1;
     series.fillOpacity = 0.2;
-    series.mainContainer.mask = undefined;
     series.connect = false;
 
     const bullet = series.bullets.push(new am4charts.Bullet());
@@ -91,9 +90,10 @@ export const OperatorSparkline = ({
   return (
     <div
       ref={chartContainerRef}
+      className="on-time-operator-sparkline"
       role="img"
       aria-label={title}
-      style={{ width, height }}
+      style={{ width: "100%", maxWidth: width, height }}
     />
   );
 };

--- a/frontend-two/components/on-time/OperatorSparkline.tsx
+++ b/frontend-two/components/on-time/OperatorSparkline.tsx
@@ -9,6 +9,8 @@ interface OperatorSparklineProps {
   width?: string | number;
   height?: number;
   title?: string;
+  fromTimestamp?: string;
+  toTimestamp?: string;
 }
 
 function buildChartData(data: TimeSeriesData[]) {
@@ -24,8 +26,10 @@ function buildChartData(data: TimeSeriesData[]) {
 export const OperatorSparkline = ({
   data,
   width = "100%",
-  height = 44,
+  height = 60,
   title = "On time stats for the selected duration",
+  fromTimestamp,
+  toTimestamp,
 }: OperatorSparklineProps) => {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<am4charts.XYChart | null>(null);
@@ -34,6 +38,7 @@ export const OperatorSparkline = ({
   useEffect(() => {
     if (!chartContainerRef.current || chartData.length === 0) return;
 
+    am4core.unuseAllThemes();
     am4core.useTheme(am4themesMicrochart);
 
     const chart = am4core.create(chartContainerRef.current, am4charts.XYChart);
@@ -49,6 +54,14 @@ export const OperatorSparkline = ({
     dateAxis.startLocation = 0.5;
     dateAxis.endLocation = 0.5;
 
+    if (fromTimestamp) {
+      dateAxis.min = new Date(fromTimestamp).getTime();
+    }
+
+    if (toTimestamp) {
+      dateAxis.max = new Date(toTimestamp).getTime();
+    }
+
     const valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
     valueAxis.min = 0;
     valueAxis.max = 1;
@@ -60,6 +73,7 @@ export const OperatorSparkline = ({
     series.stroke = am4core.color("#6A3D9A");
     series.strokeWidth = 1;
     series.fillOpacity = 0.2;
+    series.mainContainer.mask = undefined;
     series.connect = false;
 
     const bullet = series.bullets.push(new am4charts.Bullet());
@@ -68,6 +82,7 @@ export const OperatorSparkline = ({
     circle.width = 3;
     circle.height = 3;
     circle.strokeWidth = 0;
+    chart.maskBullets = false;
 
     const gradient = new am4core.LinearGradient();
     gradient.addColor(am4core.color("#6A3D9A"));

--- a/frontend-two/components/on-time/OperatorSparkline.tsx
+++ b/frontend-two/components/on-time/OperatorSparkline.tsx
@@ -6,7 +6,7 @@ import am4themesMicrochart from "@amcharts/amcharts4/themes/microchart";
 
 interface OperatorSparklineProps {
   data: TimeSeriesData[];
-  width?: number;
+  width?: string | number;
   height?: number;
   title?: string;
 }
@@ -23,7 +23,7 @@ function buildChartData(data: TimeSeriesData[]) {
 
 export const OperatorSparkline = ({
   data,
-  width = 220,
+  width = "100%",
   height = 44,
   title = "On time stats for the selected duration",
 }: OperatorSparklineProps) => {

--- a/frontend-two/components/table/PagingPanel.tsx
+++ b/frontend-two/components/table/PagingPanel.tsx
@@ -80,6 +80,7 @@ export const PagingPanel = ({
             <a
               href="#"
               className="govuk-link govuk-!-margin-bottom-0"
+              style={{ textDecoration: "none" }}
               onClick={(e) => {
                 e.preventDefault();
                 onPageChange(currentPage - 1);
@@ -118,10 +119,12 @@ export const PagingPanel = ({
             <a
               href="#"
               className="govuk-link govuk-!-margin-bottom-0"
+              style={{ textDecoration: "none" }}
               onClick={(e) => {
                 e.preventDefault();
                 onPageChange(currentPage + 1);
               }}
+
             >
               Next »
             </a>

--- a/frontend-two/components/table/PagingPanel.tsx
+++ b/frontend-two/components/table/PagingPanel.tsx
@@ -124,7 +124,6 @@ export const PagingPanel = ({
                 e.preventDefault();
                 onPageChange(currentPage + 1);
               }}
-
             >
               Next »
             </a>

--- a/frontend-two/components/table/SortedPaginatedTable.tsx
+++ b/frontend-two/components/table/SortedPaginatedTable.tsx
@@ -132,7 +132,7 @@ export const SortedPaginatedTable = <T,>({
   ];
 
   const pagination =
-    enablePagination && totalPages > 1
+    enablePagination
       ? {
           currentPage,
           totalPages,

--- a/frontend-two/components/table/SortedPaginatedTable.tsx
+++ b/frontend-two/components/table/SortedPaginatedTable.tsx
@@ -23,6 +23,7 @@ export interface SortedPaginatedTableProps<T> {
   data: T[];
   getRowValue: (row: T, column: string) => string | number;
   renderRow: (row: T) => SortableTableRow;
+  enablePagination?: boolean;
   onDisplayedDataChange?: (rows: T[]) => void;
   onPageDataChange?: (rows: T[]) => void;
   footerAction?: ReactNode;
@@ -44,6 +45,7 @@ export const SortedPaginatedTable = <T,>({
   data,
   getRowValue,
   renderRow,
+  enablePagination = true,
   onDisplayedDataChange,
   onPageDataChange,
   footerAction,
@@ -94,11 +96,15 @@ export const SortedPaginatedTable = <T,>({
     onSortChange?.(column, order);
   };
 
-  const totalPages = Math.ceil(sortedData.length / pageSize);
+  const totalPages = enablePagination
+    ? Math.ceil(sortedData.length / pageSize)
+    : 1;
   const pageData = useMemo(
     () =>
-      sortedData.slice(currentPage * pageSize, (currentPage + 1) * pageSize),
-    [sortedData, currentPage, pageSize],
+      enablePagination
+        ? sortedData.slice(currentPage * pageSize, (currentPage + 1) * pageSize)
+        : sortedData,
+    [sortedData, currentPage, pageSize, enablePagination],
   );
 
   useEffect(() => {
@@ -126,7 +132,7 @@ export const SortedPaginatedTable = <T,>({
   ];
 
   const pagination =
-    totalPages > 1
+    enablePagination && totalPages > 1
       ? {
           currentPage,
           totalPages,

--- a/frontend-two/components/table/SortedPaginatedTable.tsx
+++ b/frontend-two/components/table/SortedPaginatedTable.tsx
@@ -131,18 +131,17 @@ export const SortedPaginatedTable = <T,>({
     ...pageData.map(renderRow),
   ];
 
-  const pagination =
-    enablePagination
-      ? {
-          currentPage,
-          totalPages,
-          pageSize,
-          rowCount: sortedData.length,
-          onPageChange: setCurrentPage,
-          noun: paginationNoun ?? "row",
-          alignment: paginationAlignment,
-        }
-      : undefined;
+  const pagination = enablePagination
+    ? {
+        currentPage,
+        totalPages,
+        pageSize,
+        rowCount: sortedData.length,
+        onPageChange: setCurrentPage,
+        noun: paginationNoun ?? "row",
+        alignment: paginationAlignment,
+      }
+    : undefined;
 
   return (
     <>

--- a/frontend-two/pages/on-time/[nocCode].tsx
+++ b/frontend-two/pages/on-time/[nocCode].tsx
@@ -435,7 +435,12 @@ const OnTimeOperatorPage = () => {
             }}
             onResetRefineResults={() => setRefineResultsFilters({})}
             dateRange={dateRange}
-            onDateRangeChange={(value) => setDateRange(value ?? null)}
+            onDateRangeChange={(value) => {
+              setDateRange(value ?? null);
+              if (value) {
+                setSelectedDatePreset("Custom");
+              }
+            }}
             datePresetOptions={DATE_PRESET_OPTIONS}
             selectedDatePreset={selectedDatePreset}
             onDatePresetChange={handleDatePresetChange}

--- a/frontend-two/pages/on-time/[nocCode]/[lineId].tsx
+++ b/frontend-two/pages/on-time/[nocCode]/[lineId].tsx
@@ -415,7 +415,12 @@ const OnTimeServicePage = () => {
             }}
             onResetRefineResults={() => setRefineResultsFilters({})}
             dateRange={dateRange}
-            onDateRangeChange={(value) => setDateRange(value ?? null)}
+            onDateRangeChange={(value) => {
+              setDateRange(value ?? null);
+              if (value) {
+                setSelectedDatePreset("Custom");
+              }
+            }}
             datePresetOptions={DATE_PRESET_OPTIONS}
             selectedDatePreset={selectedDatePreset}
             onDatePresetChange={handleDatePresetChange}

--- a/frontend-two/pages/on-time/index.tsx
+++ b/frontend-two/pages/on-time/index.tsx
@@ -238,7 +238,12 @@ const OnTimeIndexPage = () => {
         }}
         onResetRefineResults={() => setRefineResultsFilters({})}
         dateRange={dateRange}
-        onDateRangeChange={(value) => setDateRange(value ?? null)}
+        onDateRangeChange={(value) => {
+          setDateRange(value ?? null);
+          if (value) {
+            setSelectedDatePreset("Custom");
+          }
+        }}
         datePresetOptions={DATE_PRESET_OPTIONS}
         selectedDatePreset={selectedDatePreset}
         onDatePresetChange={handleDatePresetChange}

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -2453,6 +2453,10 @@ $day-width: 46px;
     flex: 1 1 50%;
     min-width: 0;
   }
+
+  .summary-stat-container .summary-stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .summary-stats-grid {

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -1488,6 +1488,18 @@ $day-width: 46px;
   overflow-wrap: anywhere;
 }
 
+.on-time-operator-table__sparkline-cell {
+  overflow: hidden;
+  padding-right: 0;
+}
+
+.on-time-operator-sparkline {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  margin-left: auto;
+}
+
 .sortable-table__align--right {
   justify-content: flex-end;
   width: 100%;


### PR DESCRIPTION
Ticket: https://busopendataservice.atlassian.net/browse/DBODS-2236

As part of addressing comments on this ticket, I have also made a small change to the FeedTable component, to remove the underlining from links in the table there too

Mainly formatting issues. Key change is introducing `enable_pagination` toggle in `SortedPaginatedTable` to disable pagination for `OnTimeStopsTable`