### PR TITLE
DBODS-2258: Change CSS styling to match prod

### DIFF
--- a/frontend-two/components/on-time/OnTimeHelpdesk/OnTimeHelpdeskButton.tsx
+++ b/frontend-two/components/on-time/OnTimeHelpdesk/OnTimeHelpdeskButton.tsx
@@ -13,7 +13,7 @@ export const OnTimeHelpdeskButton = () => {
         onClick={() => setIsHelpdeskOpen(true)}
         type="button"
       >
-        <QuestionInCircleIcon aria-hidden style={{ minWidth: "20px" }}/>
+        <QuestionInCircleIcon aria-hidden style={{ minWidth: "20px" }} />
         How are these numbers calculated?
       </button>
       <OnTimeHelpdeskPanel

--- a/frontend-two/components/on-time/OnTimeHelpdesk/OnTimeHelpdeskButton.tsx
+++ b/frontend-two/components/on-time/OnTimeHelpdesk/OnTimeHelpdeskButton.tsx
@@ -9,11 +9,11 @@ export const OnTimeHelpdeskButton = () => {
     <>
       <button
         className="helpdesk-link govuk-body govuk-link button-link"
-        style={{ textDecoration: "underline" }}
+        style={{ textDecoration: "underline", textDecorationThickness: "1px" }}
         onClick={() => setIsHelpdeskOpen(true)}
         type="button"
       >
-        <QuestionInCircleIcon aria-hidden width="20" height="20" />
+        <QuestionInCircleIcon aria-hidden style={{ minWidth: "20px" }}/>
         How are these numbers calculated?
       </button>
       <OnTimeHelpdeskPanel

--- a/frontend-two/components/on-time/OnTimeHelpdesk/OnTimeHelpdeskButton.tsx
+++ b/frontend-two/components/on-time/OnTimeHelpdesk/OnTimeHelpdeskButton.tsx
@@ -13,7 +13,7 @@ export const OnTimeHelpdeskButton = () => {
         onClick={() => setIsHelpdeskOpen(true)}
         type="button"
       >
-        <QuestionInCircleIcon aria-hidden style={{ minWidth: "20px" }} />
+        <QuestionInCircleIcon />
         How are these numbers calculated?
       </button>
       <OnTimeHelpdeskPanel

--- a/frontend-two/pages/on-time/index.tsx
+++ b/frontend-two/pages/on-time/index.tsx
@@ -292,32 +292,34 @@ const OnTimeIndexPage = () => {
                     overview={summaryStats}
                   />
                 </div>
-                <SummaryStatsGrid
-                  onTimeCount={summaryStats?.onTime ?? null}
-                  lateCount={summaryStats?.late ?? null}
-                  earlyCount={summaryStats?.early ?? null}
-                  incompleteCount={summaryStats?.noData ?? null}
-                  recordedStopDepartures={
-                    recordedStopDepartures > 0 ? recordedStopDepartures : null
-                  }
-                  totalStopDepartures={
-                    totalStopDepartures > 0 ? totalStopDepartures : null
-                  }
-                  incompleteBreakdown={summaryStats?.incomplete ?? null}
-                  averageDelay={summaryStats?.averageDelay ?? null}
-                />
-              </div>
-              <div className="summary-map-container">
-                {config?.mapboxToken && config?.mapboxStyle ? (
-                  <OnTimeBoundariesMap
-                    mapboxToken={config.mapboxToken}
-                    mapboxStyle={config.mapboxStyle}
-                    adminAreas={adminAreas}
-                    selectedAdminAreaNames={selectedAdminAreas}
+                <div className="summary-stats-grid-map-container">
+                  <SummaryStatsGrid
+                    onTimeCount={summaryStats?.onTime ?? null}
+                    lateCount={summaryStats?.late ?? null}
+                    earlyCount={summaryStats?.early ?? null}
+                    incompleteCount={summaryStats?.noData ?? null}
+                    recordedStopDepartures={
+                      recordedStopDepartures > 0 ? recordedStopDepartures : null
+                    }
+                    totalStopDepartures={
+                      totalStopDepartures > 0 ? totalStopDepartures : null
+                    }
+                    incompleteBreakdown={summaryStats?.incomplete ?? null}
+                    averageDelay={summaryStats?.averageDelay ?? null}
                   />
-                ) : (
-                  <p className="govuk-body">Map is unavailable</p>
-                )}
+                </div>
+                <div className="summary-map-container">
+                  {config?.mapboxToken && config?.mapboxStyle ? (
+                    <OnTimeBoundariesMap
+                      mapboxToken={config.mapboxToken}
+                      mapboxStyle={config.mapboxStyle}
+                      adminAreas={adminAreas}
+                      selectedAdminAreaNames={selectedAdminAreas}
+                    />
+                  ) : (
+                    <p className="govuk-body">Map is unavailable</p>
+                  )}
+                </div>
               </div>
             </div>
           </ChartNoDataWrapper>

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -373,8 +373,11 @@
 .helpdesk-link {
   display: inline-flex;
   align-items: center;
+  text-align: left;
   gap: 4px;
   white-space: nowrap;
+  line-height: 25px;
+  appearance: auto;
 }
 
 .on-time-helpdesk-panel-drawer {
@@ -2697,6 +2700,10 @@ $day-width: 46px;
   .stat {
     margin-bottom: 0;
   }
+}
+
+.summary-stats-grid-map-container {
+  display: flex;
 }
 
 .feed-status-summary {

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -374,10 +374,20 @@
   display: inline-flex;
   align-items: center;
   text-align: left;
-  gap: 4px;
-  white-space: nowrap;
-  line-height: 25px;
   appearance: auto;
+  @include govuk-font(19);
+  svg {
+    display: inline-flex;
+    color: govuk-colour("blue");
+    width: 20px;
+    height: 20px;
+    margin-right: govuk-spacing(1);
+  }
+  &:focus {
+    svg {
+      color: govuk-colour("black");
+    }
+  }
 }
 
 .on-time-helpdesk-panel-drawer {


### PR DESCRIPTION
The link text for the `OnTimeHelpdeskButton` in prod has different CSS attributes to the code `abods-two-next-js`. 

The differences spotted by QA are as follows:
- appearancebutton
- height
- line-height
- text-align
- text-decoration-thickness
- width

The `height` and `width` attributes are reactive and change with the window size so have been kept as is. I have also made a couple of changes to better support the page layout when the window gets smaller. 