### PR TITLE
fix layout on on-time index page

### DIFF
--- a/frontend-two/pages/on-time/index.tsx
+++ b/frontend-two/pages/on-time/index.tsx
@@ -292,34 +292,32 @@ const OnTimeIndexPage = () => {
                     overview={summaryStats}
                   />
                 </div>
-                <div className="summary-stats-grid-map-container">
-                  <SummaryStatsGrid
-                    onTimeCount={summaryStats?.onTime ?? null}
-                    lateCount={summaryStats?.late ?? null}
-                    earlyCount={summaryStats?.early ?? null}
-                    incompleteCount={summaryStats?.noData ?? null}
-                    recordedStopDepartures={
-                      recordedStopDepartures > 0 ? recordedStopDepartures : null
-                    }
-                    totalStopDepartures={
-                      totalStopDepartures > 0 ? totalStopDepartures : null
-                    }
-                    incompleteBreakdown={summaryStats?.incomplete ?? null}
-                    averageDelay={summaryStats?.averageDelay ?? null}
+                <SummaryStatsGrid
+                  onTimeCount={summaryStats?.onTime ?? null}
+                  lateCount={summaryStats?.late ?? null}
+                  earlyCount={summaryStats?.early ?? null}
+                  incompleteCount={summaryStats?.noData ?? null}
+                  recordedStopDepartures={
+                    recordedStopDepartures > 0 ? recordedStopDepartures : null
+                  }
+                  totalStopDepartures={
+                    totalStopDepartures > 0 ? totalStopDepartures : null
+                  }
+                  incompleteBreakdown={summaryStats?.incomplete ?? null}
+                  averageDelay={summaryStats?.averageDelay ?? null}
+                />
+              </div>
+              <div className="summary-map-container">
+                {config?.mapboxToken && config?.mapboxStyle ? (
+                  <OnTimeBoundariesMap
+                    mapboxToken={config.mapboxToken}
+                    mapboxStyle={config.mapboxStyle}
+                    adminAreas={adminAreas}
+                    selectedAdminAreaNames={selectedAdminAreas}
                   />
-                </div>
-                <div className="summary-map-container">
-                  {config?.mapboxToken && config?.mapboxStyle ? (
-                    <OnTimeBoundariesMap
-                      mapboxToken={config.mapboxToken}
-                      mapboxStyle={config.mapboxStyle}
-                      adminAreas={adminAreas}
-                      selectedAdminAreaNames={selectedAdminAreas}
-                    />
-                  ) : (
-                    <p className="govuk-body">Map is unavailable</p>
-                  )}
-                </div>
+                ) : (
+                  <p className="govuk-body">Map is unavailable</p>
+                )}
               </div>
             </div>
           </ChartNoDataWrapper>

--- a/frontend-two/styles/common.scss
+++ b/frontend-two/styles/common.scss
@@ -2712,10 +2712,6 @@ $day-width: 46px;
   }
 }
 
-.summary-stats-grid-map-container {
-  display: flex;
-}
-
 .feed-status-summary {
   width: 100%;
   margin-bottom: govuk-spacing(2);


### PR DESCRIPTION
Undoing change I included with previous PR

Had introduced a new container to format the map and summary stats on the on-time page. This however doesn't work as intended when the window is full screen.