### PR TITLE
DBODS-2447: Interim fix for corridors display

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.74
+version: v1.0.75

--- a/abods-api/prisma/schema.prisma
+++ b/abods-api/prisma/schema.prisma
@@ -404,9 +404,6 @@ model corridor {
   corridor_id     Int                   @id @default(autoincrement()) // TODO: fix - bigint and not id in database
   corridor_name   String // TODO: fix - nullable in db
   organisation_id Int // TODO: fix - nullable in db
-  user_id         Int // TODO: fix - nullable in db
-  bods_user       bods_user             @relation(fields: [user_id], references: [id])
-  bods_userorg    bods_userorganisation @relation(fields: [user_id, organisation_id], references: [user_id, organisation_id])
   corridor_stops  corridor_stops[] // TODO: fix - not in db
 }
 
@@ -522,7 +519,6 @@ view bods_user {
   account_type      Int?
   admin_org         Int?
   userOrganisations bods_userorganisation[]
-  corridor          corridor[]
   created_by_alerts Alert[]                 @relation("created_by_user")
   send_to_alerts    Alert[]                 @relation("send_to_user")
   Tokens            Tokens[]
@@ -533,7 +529,6 @@ view bods_userorganisation {
   organisation_id Int
   user            bods_user         @relation(fields: [user_id], references: [id])
   organisation    bods_organisation @relation(fields: [organisation_id], references: [id])
-  corridor        corridor[]
 
   @@id([user_id, organisation_id])
 }

--- a/abods-api/src/lib/corridor.ts
+++ b/abods-api/src/lib/corridor.ts
@@ -1,5 +1,4 @@
 import {
-  bods_user,
   corridor,
   corridor_stops,
   naptan_adminarea,
@@ -32,7 +31,6 @@ export interface StopWithLocality {
 export type CorridorStopsWithNaptanStops = corridor_stops & StopWithLocality;
 
 export type CorridorResultsType = corridor & {
-  bods_user?: bods_user;
   corridor_stops?: CorridorStopsWithNaptanStops[];
 };
 
@@ -82,7 +80,6 @@ export const getCorridorList = (db: PrismaClient, sessionUser: SessionUser) => {
     },
     include: {
       corridor_stops: true,
-      bods_user: true,
     },
   });
 };
@@ -98,7 +95,6 @@ export const getCorridor = (
       organisation_id: { in: sessionUser.orgs.map((org) => org.id) },
     },
     include: {
-      bods_user: true,
       corridor_stops: {
         include: {
           naptan_stop: {

--- a/abods-api/src/lib/test/db.ts
+++ b/abods-api/src/lib/test/db.ts
@@ -545,7 +545,6 @@ export async function createCorridorTable(db: Kysely<DB>) {
     .addColumn("corridor_id", "serial", (col) => col.primaryKey())
     .addColumn("corridor_name", "varchar", (col) => col.notNull())
     .addColumn("organisation_id", "integer", (col) => col.notNull())
-    .addColumn("user_id", "integer", (col) => col.notNull())
     .execute();
 }
 

--- a/abods-api/src/lib/test/utils.ts
+++ b/abods-api/src/lib/test/utils.ts
@@ -444,7 +444,6 @@ export const createCorridorTablesAndData = async (dbKysely: Kysely<DB>) => {
         corridor_id: 1,
         corridor_name: "Test Corridor",
         organisation_id: 1,
-        user_id: 1,
       })
       .execute(),
     dbKysely

--- a/abods-api/src/resolvers/corridor/corridorResolver.int.test.ts
+++ b/abods-api/src/resolvers/corridor/corridorResolver.int.test.ts
@@ -125,7 +125,6 @@ describe("Corridor resolver integration", () => {
         corridor_id: 2,
         corridor_name: "Second Corridor",
         organisation_id: 1,
-        user_id: 1,
       })
       .execute();
     await kysely

--- a/abods-api/src/resolvers/corridor/corridorResolver.test.ts
+++ b/abods-api/src/resolvers/corridor/corridorResolver.test.ts
@@ -84,7 +84,6 @@ beforeEach(() => {
 });
 
 const mockCorridorResult: CorridorResultsType = {
-  user_id: 1,
   corridor_id: 1,
   corridor_name: "Test Corridor",
   organisation_id: 123,
@@ -843,14 +842,12 @@ describe("listCorridors", () => {
       corridor_id: 1,
       corridor_name: "Corridor 1",
       organisation_id: 123,
-      user_id: 1,
       corridor_stops: [],
     },
     {
       corridor_id: 2,
       corridor_name: "Corridor 2",
       organisation_id: 123,
-      user_id: 1,
       corridor_stops: [],
     },
   ] as never);

--- a/abods-api/src/resolvers/corridor/mutation.int.test.ts
+++ b/abods-api/src/resolvers/corridor/mutation.int.test.ts
@@ -91,7 +91,6 @@ describe("Corridor mutation integration", () => {
         corridor_id: 3,
         corridor_name: "Corridor To Update",
         organisation_id: 1,
-        user_id: 1,
       })
       .execute();
     await kysely
@@ -146,7 +145,6 @@ describe("Corridor mutation integration", () => {
         corridor_id: 4,
         corridor_name: "Corridor To Delete",
         organisation_id: 1,
-        user_id: 1,
       })
       .execute();
     await kysely

--- a/abods-api/src/resolvers/corridor/mutation.test.ts
+++ b/abods-api/src/resolvers/corridor/mutation.test.ts
@@ -71,7 +71,6 @@ describe("createCorridor", () => {
       data: {
         corridor_name: "Test Corridor",
         organisation_id: 10,
-        user_id: 1,
       },
       select: {
         corridor_id: true,

--- a/abods-api/src/resolvers/corridor/mutation.ts
+++ b/abods-api/src/resolvers/corridor/mutation.ts
@@ -30,7 +30,6 @@ export const createCorridor: MutationResolvers["createCorridor"] = async (
       // This won't be visible to any other orgs they are assigned to.
       // Visibility will be somewhat random, though consistent because we sort the org numbers
       organisation_id: orgIds[0],
-      user_id: user.id,
     },
     select: {
       corridor_id: true,


### PR DESCRIPTION
Ticket: https://busopendataservice.atlassian.net/browse/DBODS-2447

- Display corridors to users on ABODS without using the corridor.user_id to do any additional lookup
- Remove user_id, bods_user and bods_userorg from schema.prisma as they are unused