### PR TITLE
Add missing association

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.76
+version: v1.0.77

--- a/abods-api/template.yaml
+++ b/abods-api/template.yaml
@@ -534,6 +534,9 @@ Resources:
             - OPTIONS
           OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf # Managed-CORS-S3Origin
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimised
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt CloudFrontRewriteFunctionV2.FunctionARN
         CacheBehaviors:
           - TargetOriginId: frontendBucketV2
             PathPattern: "/freshdesk/*"


### PR DESCRIPTION
Adding this as it's needed for attributing the function to the distribution. Missed bringing it in along with the function itself